### PR TITLE
feat: 추가 스타일 varient설정(#13)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1475,17 +1475,6 @@
         }
       }
     },
-    "node_modules/@isaacs/fs-minipass": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-      "dependencies": {
-        "minipass": "^7.0.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
@@ -1564,17 +1553,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@napi-rs/wasm-runtime": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.11.tgz",
-      "integrity": "sha512-9DPkXtvHydrcOsopiYpUgPHpmj0HWZKMUnL2dZqpvC42lsratuBG06V5ipyno0fUek5VlFsNQ+AcFATSrJXgMA==",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "^1.4.3",
-        "@emnapi/runtime": "^1.4.3",
-        "@tybys/wasm-util": "^0.9.0"
-      }
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1634,6 +1612,39 @@
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
+      "integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.11",
@@ -6751,6 +6762,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.4.0.tgz",
+      "integrity": "sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/tailwindcss": {

--- a/src/App.css
+++ b/src/App.css
@@ -51,6 +51,12 @@
 }
 
 @layer base {
+  * {
+    @apply border-border outline-ring/50;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
   /* 헤딩  */
   h1 {
     font-size: var(--text-4xl);
@@ -147,12 +153,17 @@
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
 }
-
-@layer base {
-  * {
-    @apply border-border outline-ring/50;
+@layer components {
+  /* 버튼 커스텀 클래스 색상
+  지원내역의 파란색 버튼임
+   */
+  .btn-active-blue {
+    @apply bg-blue-500! text-white! hover:bg-blue-600! active:bg-blue-700!;
   }
-  body {
-    @apply bg-background text-foreground;
+  .btn-active-red {
+    @apply hover:bg-danger-500! active:bg-danger-600! hover:border-none! hover:text-white!;
+  }
+  .btn-active-yellow {
+    @apply hover:bg-primary-500! active:bg-primary-600! hover:border-none! hover:text-white!;
   }
 }

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -13,8 +13,13 @@ const buttonVariants = cva(
           'bg-primary text-primary-foreground hover:bg-primary-700 active:bg-primary-900',
         danger:
           'bg-danger-500 text-white hover:bg-danger-600 active:bg-danger-800 dark:focus-visible:ring-danger-400',
+        success:
+          'bg-success-500 text-white hover:bg-success-600 active:bg-success-800 dark:focus-visible:ring-success-400',
         outline:
           'border bg-background shadow-xs hover:bg-gray-50 text-accent-foreground active:bg-gray-100',
+        'outline-primary':
+          'border border-primary-500 bg-background shadow-xs text-primary-600 hover:bg-primary-50 active:bg-primary-100',
+
         secondary:
           'bg-secondary text-secondary-foreground hover:bg-gray-200 active:bg-gray-300 active:text-white',
         ghost: 'hover:bg-accent text-accent-foreground active:bg-gray-200',
@@ -50,7 +55,7 @@ function Button({
   return (
     <Comp
       data-slot="button"
-      className={cn(buttonVariants({ variant, size, className }))}
+      className={cn(buttonVariants({ size, className, variant }))}
       {...props}
     />
   )


### PR DESCRIPTION
- 버튼의 커스텀 클래스 추가함
- 태일윈드에서 클래스명 추가함

<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈
- closes #13

## 📑 구현 사항
- 성공상태의 varient추가 (success)
- 자주 사용하지 않는 스타일 내역들 ( 파랑색버튼, 노란색 아웃라인버튼) 은 클래스명으로 커스터마이징 하여 지정해두었음

## 🌀 어려웠던 점 / 고민했던 부분
- 버튼 컴포넌트에서 직관적으로 아이콘 전용 버튼 컴포넌트를 만들고자 하였음 
- 그러나 수현조교님과 채은코치님의 피드백으로, 공통 컴포넌트 내에서, 스타일 추가만 하자로 결론이 나왔다 

### 대화 내용 요약
```
만들어둔 Button컴포넌트에서 충분히 아이콘, 텍스트를 받아올 수 있는데 다시 쪼갤 필요가 있을까?
이미 고정된 아이콘이 있는 컴포넌트를 다른 곳에서 얼마나 재사용이 될 수 있을까?
컴포넌트를 다시 쪼개서 사용한 코드를 다른 사람이 봤을 때 어떤 코드인지 알기 어려울 것 같다.
```

- 추가로 태일윈드의 커스텀 클래스명이 shadcn에서 varient 오버라이드 되지 않는 점을 발견하였다. 
- 해결법은 느낌표를 붙여서 오버라이드 되도록 강제성 추가 하였다... 
<details><summary>커스텀 클래스 설정 (태일윈드)
</summary>

### 우당탕탕 트러블슈팅?
유독 한가지 튀는 버튼이 존재했음

나머지는 키컬러인 노랑색인데, ‘지원내역’ 이 친구만 퍼렁색임 

그래서 varient설정하긴 좀 아까우니, 클래스명으로 지정해보려고 함 

태일윈드의 component로 커스텀 스타일 클래스 설정함 

```css
@layer components {
  .btn-active-primary {
    @apply bg-blue-500 text-white hover:bg-blue-600 active:bg-blue-700;
  }
}
```

### 버튼 컴포넌트 클래스명 사용하기

```tsx
      <Button className="btn-active-blue">
        <ScrollText />
        지원내역
      </Button>
      
            혹은
     <Button className="btn-active-blue" variant={'ghost'}>
        <ScrollText />
        지원내역
      </Button>
```

- 사용시 위와 같이 적용했으나, shadcn에서 설정한 기본 버튼 스타일만 나오고, 내가 설정한 커스텀 클래스가 오버라이드가 되지 않았음
- 그래서 디폴트 varient를 설정하지 않도록 ‘ghost’ 로 츄라이 해도 오버라이드가 안되었음
- 그래서 중요도 강제로 끌어올려보기로 했음

### 강제 스타일 적용
<img width="618" height="274" alt="image" src="https://github.com/user-attachments/assets/09c2eac0-de93-40db-a104-d2f63fe42bbb" />


```css
  .btn-active-blue {
    @apply bg-blue-500! text-white! hover:bg-blue-600! active:bg-blue-700!;
  }
```

- 느낌표 통해서 강제로 스타일 속성을 끌어올려버렸음
- 오호라 , 그랬더니 결과는 성공적! 원하는 퍼렁색 버튼이 생성되었음 !
- 음 ,, 근데 왜 이런걸까 갑자기 궁금해졌으며, shadcn의 버튼 컴포넌트의 스타일 순서 때문에 영향을 주는 것일까? 싶었음

> **`cn()` 함수의 병합 순서가 중요한걸까?**
> 

```css
function Button({
  className,
  variant,
  size,
  asChild = false,
  ...props
}: React.ComponentProps<'button'> &
  VariantProps<typeof buttonVariants> & {
    asChild?: boolean
  }) {
  const Comp = asChild ? Slot : 'button'

  return (
    <Comp
      data-slot="button"
     //className={cn(buttonVariants({ variant, size, className }))}
      className={cn(buttonVariants({ variant, size, className }))}
      {...props}
    />
  )
}
```

- 버튼 컴포넌트의 클래스네임 병합순서를 보면 variant 가 가장 앞에 있었다.
- 이걸 className 뒤로 보내면 className 오버라이드가 우선적으로 되는지 ( 즉 , 느낌표 없이 가능한지 궁금 ) 테스트 해봐야겠다 ㅋ

```tsx
return (
    <Comp
      data-slot="button"
      // className={cn(buttonVariants({ variant, size, className }))}
      className={cn(buttonVariants({ size, className, variant }))}
      {...props}
    />
  )
```

- 먼저 가장 뒤로 보냈고, 스타일 느낌표도 모두 제거함 ㅋ
- 결과는??  음 똑같았음 ;;

<aside>
<img src="notion://custom_emoji/00feaf78-d356-41ee-90f9-616e7f73fd77/1f3caf56-50aa-8079-91f2-007ab94924a7" alt="notion://custom_emoji/00feaf78-d356-41ee-90f9-616e7f73fd77/1f3caf56-50aa-8079-91f2-007ab94924a7" width="40px" />

**`buttonVariants({ size, className, variant })`의 내부 동작:**

- `class-variance-authority` (cva)는 variant와 size에 따라 클래스를 **먼저 생성**
- `className`은 단순히 **추가**될 뿐, variant의 클래스를 대체하지 않음
- 매개변수 순서는 cva의 내부 로직에 영향을 주지 않음
</aside>

- 그래서 순서는 아무런 소용이 없다고함
- 그래서 shadcn의 커스텀 부분을 만져보자! 생각했음
- 아래와 같이 끄적여봄

```css
const buttonVariants = cva(
  "inline-flex items-center justify-center gap-2...",
  {
    variants: {
      variant: {
        primary: '...',
        danger: '...',
        outline: '...',
        'outline-primary': '...',
        secondary: '...',
        ghost: '...',
      },
      size: {
        default: '...',
        sm: '...',
        // ...
      },
      theme: {  // 새로운 variant 카테고리
        'active-blue': 'bg-blue-500 text-white hover:bg-blue-600 active:bg-blue-700',
      },
    },
    defaultVariants: {
      variant: 'primary',
      size: 'default',
    },
  }
)
사용:
<Button variant="ghost" theme="active-blue">
  <ScrollText />
  지원내역
</Button>
```

- 결국 varient동일하게 쓰자는거임
- 이런경우엔 그냥 처음처럼 느낌표로 ….. 태일윈드 스타일 컴포넌트 설정하는 걸로 …… 흥
</details>


## 📸 구현 이미지 (선택)
### 북마크 상태
![북마크지원내역](https://github.com/user-attachments/assets/b9cc1fbd-370d-4571-a5d7-7cf45e3082c2)


### 승인,거절 스타일 추가 
![승인거절](https://github.com/user-attachments/assets/533daf69-4cd8-459b-94be-3795407552db)


## ❇️ 코드 설명 (선택)
### 지원내역 파란색 버튼 
```tsx
<Button classname="btn-active-blue">
  <ScrollText />
  지원내역
</Button>
```
- 미리 설정해둔 클래스명으로 버튼 스타일 변경 가능 

### 북마크아이콘
```tsx
<Button 
  variant={isBookmarked?:"primary":"secondary"} 
  size="icon" 
  className="rounded-full"
  onClick={() => setIsBookmarked(!isBookmarked)}
>
  <Star />
</Button>
```
 - 북마크 상태이면 primary 색상(배경노랑색)
 - 북마크 아니라면? secondary 색상(회색)

### 수정아이콘,삭제아이콘 hover이벤트 
```tsx
      <Button variant={'outline'} size={'icon'} className="btn-active-yellow">
        <ScrollText />
      </Button>
```
- 노란색 이벤트는 클래스네임 `btn-active-yellow`
- 빨간색 이벤트는 클래스네임 `btn-active-red`
## 💬 리뷰 요청사항 (선택)
> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.
1. active 클래스명이 괜찮은지 App.css에서의 `@layer components ` 클래스명입니다. 
2. 아이콘 버튼 사용시 각자 `Lucid-icon`목록에서 조회하여, 사용예시 코드처럼 적용해주시면 됩니다,. 추가적으로 설명드릴게 더 필요하실까요 ? 