### PR TITLE
feat: 알림 애니메이션 추가(#33)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@radix-ui/react-slot": "^1.2.4",
         "@tanstack/react-query": "^5.80.7",
         "axios": "^1.10.0",
+        "framer-motion": "^12.23.24",
         "lucide-react": "^0.515.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -3846,6 +3847,33 @@
         "node": ">= 6"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.23.24",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.24.tgz",
+      "integrity": "sha512-HMi5HRoRCTou+3fb3h9oTLyJGBxHfW+HnNE25tAXOvVx/IvwMHK0cx7IR4a2ZU6sh3IX1Z+4ts32PcYBOqka8w==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.23.23",
+        "motion-utils": "^12.23.6",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -5102,6 +5130,21 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.23.23",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.23.tgz",
+      "integrity": "sha512-n5yolOs0TQQBRUFImrRfs/+6X4p3Q4n1dUEqt/H58Vx7OW6RF+foWEgmTVDhIWJIMXOuNNL0apKH2S16en9eiA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.23.6"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.23.6",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.6.tgz",
+      "integrity": "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@radix-ui/react-slot": "^1.2.4",
     "@tanstack/react-query": "^5.80.7",
     "axios": "^1.10.0",
+    "framer-motion": "^12.23.24",
     "lucide-react": "^0.515.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/src/components/common/header/User.tsx
+++ b/src/components/common/header/User.tsx
@@ -4,16 +4,22 @@ import topArrow from '@/assets/icons/topArrow.svg'
 import useUserData from '@/hooks/quries/useUserData'
 
 import { useState } from 'react'
-import NotificationModal from '../notification/Notification'
+import { AnimatePresence } from 'framer-motion'
+
+import NotificationModal from '../notification/NotificationModal'
 import UserModal from './UserModal'
 function User() {
   const [isUserModalOpen, setIsUserModalOpen] = useState(false)
   const [isAlarmOpen, setIsAlarmOpen] = useState(false)
+  const [isAlarmAnimating, setIsAlarmAnimating] = useState(false)
   // 로그인했을때의 모달 상태 관리
   const handleUserModal = () => {
     setIsUserModalOpen((prev) => !prev)
   }
+  // 알림 모달 토글 (애니메이션 중에는 연타 방지)
   const handleAlarmModal = () => {
+    if (isAlarmAnimating) return
+    setIsAlarmAnimating(true)
     setIsAlarmOpen((prev) => !prev)
     if (isUserModalOpen) {
       setIsUserModalOpen(false)
@@ -22,12 +28,6 @@ function User() {
   const { data } = useUserData()
   return (
     <div className="ml-auto flex">
-      {isAlarmOpen && (
-        <div
-          className="fixed inset-0 z-40 bg-black/30 md:hidden"
-          onClick={() => setIsAlarmOpen(false)}
-        />
-      )}
       <div className="flex items-center gap-8 text-base text-gray-700">
         <div className="hidden md:flex md:gap-8">
           <a href="" className="hover:text-primary-600 cursor-pointer">
@@ -50,8 +50,36 @@ function User() {
             className="h-[30px] w-[30px] cursor-pointer"
             onClick={handleAlarmModal}
           />
-          {/* 알림개수 연동 예정 */}
-          {isAlarmOpen && <NotificationModal />}
+          {/* 알림 모달,바텀시트 오픈 */}
+          {isAlarmOpen && (
+            <div
+              className="fixed inset-0 z-40 bg-black/30 md:bg-transparent"
+              onClick={() => setIsAlarmOpen(false)}
+            />
+          )}
+          {isAlarmOpen && (
+            <div
+              className="fixed inset-0 z-40 bg-black/30 md:bg-transparent"
+              onClick={() => {
+                setIsAlarmAnimating(true)
+                setIsAlarmOpen(false)
+              }}
+            />
+          )}
+          <AnimatePresence
+            mode="wait"
+            onExitComplete={() => setIsAlarmAnimating(false)}
+          >
+            {isAlarmOpen && (
+              <NotificationModal
+                onClose={() => {
+                  setIsAlarmAnimating(true)
+                  setIsAlarmOpen(false)
+                }}
+                onAnimationComplete={() => setIsAlarmAnimating(false)}
+              />
+            )}
+          </AnimatePresence>
         </div>
       </div>
       {/* 클릭하면 유저 모달 나오게 */}

--- a/src/components/common/notification/NotificationModal.tsx
+++ b/src/components/common/notification/NotificationModal.tsx
@@ -90,13 +90,6 @@ export default function NotificationModal({
       <div className="mx-auto mt-2 h-1.5 w-12 rounded-full bg-gray-200 md:hidden" />
       <div className="flex-between h-[60px] border-b border-gray-100 px-4">
         <div className="flex items-center gap-2">
-          <button
-            aria-label="알림 닫기"
-            className="flex h-8 w-8 items-center justify-center rounded-full text-gray-500 hover:bg-gray-100 md:hidden"
-            onClick={onClose}
-          >
-            ×
-          </button>
           <h5>알림</h5>
         </div>
         <button

--- a/src/components/common/notification/NotificationModal.tsx
+++ b/src/components/common/notification/NotificationModal.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router'
+import { motion, useAnimation } from 'framer-motion'
 
 import {
   useNotificationActions,
@@ -8,7 +9,15 @@ import {
 
 import NotificationCard from './NotificationCard'
 
-export default function NotificationModal() {
+type NotificationModalProps = {
+  onClose?: () => void
+  onAnimationComplete?: () => void
+}
+
+export default function NotificationModal({
+  onClose,
+  onAnimationComplete,
+}: NotificationModalProps) {
   const [activeFilter, setActiveFilter] = useState<'all' | 'unread' | 'read'>(
     'all'
   )
@@ -20,6 +29,22 @@ export default function NotificationModal() {
   const totalCount = data?.totalCount ?? 0
   const unreadCount = data?.unreadCount ?? 0
   const readCount = totalCount - unreadCount
+  const controls = useAnimation()
+  const originalOverflow = useRef<string>('')
+  const [isDesktop, setIsDesktop] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false
+    return window.matchMedia('(min-width: 768px)').matches
+  })
+
+  // 모달이 열려있는 동안 배경 스크롤 잠금 + 진입 위치 초기화
+  useEffect(() => {
+    originalOverflow.current = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    controls.start({ y: 0, opacity: 1 })
+    return () => {
+      document.body.style.overflow = originalOverflow.current
+    }
+  }, [controls])
 
   const filterOptions = [
     { key: 'all' as const, label: '전체보기', count: totalCount },
@@ -27,10 +52,53 @@ export default function NotificationModal() {
     { key: 'read' as const, label: '읽음', count: readCount },
   ]
 
+  // 데스크톱 여부 감지해 애니메이션/드래그 범위 분기
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const mql = window.matchMedia('(min-width: 768px)')
+    const handle = () => setIsDesktop(mql.matches)
+    handle()
+    mql.addEventListener('change', handle)
+    return () => mql.removeEventListener('change', handle)
+  }, [])
+
   return (
-    <div className="fixed inset-x-0 bottom-0 z-50 max-h-[475px] w-full overflow-hidden rounded-t-2xl border border-gray-200 bg-gray-50 pb-[45px] shadow-[0_-8px_24px_rgba(0,0,0,0.08)] md:absolute md:inset-auto md:top-10 md:right-0 md:w-[384px] md:rounded-lg md:shadow-xl">
-      <div className="flex-between h-[60px] border-b border-gray-200 bg-white p-4">
-        <h5>알람</h5>
+    <motion.div
+      key={isDesktop ? 'desktop' : 'mobile'}
+      initial={isDesktop ? { y: 20, opacity: 0 } : { y: '100%', opacity: 0 }}
+      animate={controls}
+      exit={isDesktop ? { y: 20, opacity: 0 } : { y: '100%', opacity: 0 }}
+      transition={{ type: 'spring', stiffness: 360, damping: 32 }}
+      drag={isDesktop ? false : 'y'}
+      dragConstraints={isDesktop ? undefined : { top: 0, bottom: 800 }}
+      dragElastic={isDesktop ? undefined : 0.2}
+      dragMomentum={false}
+      onDragEnd={
+        isDesktop
+          ? undefined
+          : (_, info) => {
+              if (info.offset.y > 80 && onClose) {
+                onClose()
+              } else {
+                controls.start({ y: 0, opacity: 1 })
+              }
+            }
+      }
+      onAnimationComplete={onAnimationComplete}
+      className="fixed inset-x-0 bottom-0 z-50 h-[70dvh] w-full overflow-hidden rounded-t-2xl border border-gray-200 bg-white pb-[45px] shadow-[0_-10px_30px_rgba(0,0,0,0.14)] md:absolute md:inset-auto md:top-10 md:right-0 md:h-[475px] md:w-[384px] md:rounded-lg md:shadow-xl"
+    >
+      <div className="mx-auto mt-2 h-1.5 w-12 rounded-full bg-gray-200 md:hidden" />
+      <div className="flex-between h-[60px] border-b border-gray-100 px-4">
+        <div className="flex items-center gap-2">
+          <button
+            aria-label="알림 닫기"
+            className="flex h-8 w-8 items-center justify-center rounded-full text-gray-500 hover:bg-gray-100 md:hidden"
+            onClick={onClose}
+          >
+            ×
+          </button>
+          <h5>알림</h5>
+        </div>
         <button
           className="text-primary-600 text-sm"
           onClick={() => {
@@ -103,6 +171,6 @@ export default function NotificationModal() {
           </>
         )}
       </div>
-    </div>
+    </motion.div>
   )
 }

--- a/src/hooks/quries/useNotifications.ts
+++ b/src/hooks/quries/useNotifications.ts
@@ -54,6 +54,7 @@ export const useNotifications = (filter: FilterKey) =>
     // 초기 로딩 중에도 안전하게 사용
     initialData: { alarms: [] as AlarmItem[], totalCount: 0, unreadCount: 0 },
     staleTime: 0, // 실시간성을 위해 캐싱하지 않고 매번 신선하게 취급
+    gcTime: 0,
     refetchOnMount: true,
     refetchOnWindowFocus: true,
   })


### PR DESCRIPTION
- 알림 반응형 css 수정 및 애니메이션 추가

<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈
- closes #33 

## 📑 구현 사항
- framer motion 라이브러리 도입 후 애니메이션 적용
- 바텀시트 css 수정

## 🌀 어려웠던 점 / 고민했던 부분
- 애니메이션 적용 시 알림 컴포넌트 애니메이션을 너무 빠르게적용했을때 생기는 오류 

## 📸 구현 이미지 (선택)
-
![무제](https://github.com/user-attachments/assets/633ad14a-85ba-4800-95ac-a91a7501f317)


## ❇️ 코드 설명 (선택)
```
const [isAlarmOpen, setIsAlarmOpen] = useState(false)
const [isAlarmAnimating, setIsAlarmAnimating] = useState(false)

if (isAlarmOpen) (
  <div className="fixed inset-0 z-40 bg-black/30 md:bg-transparent"
       onClick={() => { setIsAlarmAnimating(true); setIsAlarmOpen(false) }} />
)
<AnimatePresence mode="wait" onExitComplete={() => setIsAlarmAnimating(false)}>
  {isAlarmOpen && (
    <NotificationModal
      onClose={() => { setIsAlarmAnimating(true); setIsAlarmOpen(false) }}
    />
  )}
</AnimatePresence>
```
오류: 알림 아이콘 연속 클릭 시 모달이 중간 상태에 걸려 다시 안 열림. 
원인: 애니메이션 중 중복 토글
해결: 애니메이션 플래그로 연타 무시.

```
const [isDesktop, setIsDesktop] = useState(() => window.matchMedia('(min-width:768px)').matches)

<motion.div
  initial={isDesktop ? { y: 20, opacity: 0 } : { y: '100%', opacity: 0 }}
  exit={isDesktop ? { y: 20, opacity: 0 } : { y: '100%', opacity: 0 }}
  drag={isDesktop ? false : 'y'}
  onDragEnd={(_, info) => {
    if (info.offset.y > 80) onClose?.()
    else controls.start({ y: 0, opacity: 1 })
  }}
  className="... h-[70dvh] ... md:h-[475px] ..."
>
```
모바일: 바텀시트 슬라이드 + 드래그 닫기(80px 이상), 
PC: y=20px 슬라이드 인/아웃만 적용. key로 플랫폼 전환 시 모션 재적용.
오류: 배경이 늦게 사라지고 모달이 닫히지 않던 문제 → 내부 배경 제거, 애니메이션·드래그 로직 단일화로 해결.


## 💬 리뷰 요청사항 (선택)
> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.
