### PR TITLE
fix: 알림 모달 반응형 오류 수정(#41)

### DIFF
--- a/src/components/common/header/User.tsx
+++ b/src/components/common/header/User.tsx
@@ -2,6 +2,7 @@ import notificationIcon from '@/assets/icons/notification.svg'
 import profileIcon from '@/assets/icons/profileImg.svg'
 import topArrow from '@/assets/icons/topArrow.svg'
 import useUserData from '@/hooks/quries/useUserData'
+import useIsDesktop from '@/hooks/useIsDesktop'
 
 import { useState } from 'react'
 import { AnimatePresence } from 'framer-motion'
@@ -12,6 +13,7 @@ function User() {
   const [isUserModalOpen, setIsUserModalOpen] = useState(false)
   const [isAlarmOpen, setIsAlarmOpen] = useState(false)
   const [isAlarmAnimating, setIsAlarmAnimating] = useState(false)
+  const isDesktop = useIsDesktop()
   // 로그인했을때의 모달 상태 관리
   const handleUserModal = () => {
     setIsUserModalOpen((prev) => !prev)
@@ -51,7 +53,8 @@ function User() {
             onClick={handleAlarmModal}
           />
           {/* 알림 모달,바텀시트 오픈 */}
-          {isAlarmOpen && (
+          {/* 모바일일 때만 배경 오버레이 렌더링 */}
+          {!isDesktop && isAlarmOpen && (
             <div
               className="fixed inset-0 z-40 bg-black/30 md:bg-transparent"
               onClick={() => {
@@ -66,6 +69,7 @@ function User() {
           >
             {isAlarmOpen && (
               <NotificationModal
+                isDesktop={isDesktop}
                 onClose={() => {
                   setIsAlarmAnimating(true)
                   setIsAlarmOpen(false)

--- a/src/components/common/header/User.tsx
+++ b/src/components/common/header/User.tsx
@@ -54,12 +54,6 @@ function User() {
           {isAlarmOpen && (
             <div
               className="fixed inset-0 z-40 bg-black/30 md:bg-transparent"
-              onClick={() => setIsAlarmOpen(false)}
-            />
-          )}
-          {isAlarmOpen && (
-            <div
-              className="fixed inset-0 z-40 bg-black/30 md:bg-transparent"
               onClick={() => {
                 setIsAlarmAnimating(true)
                 setIsAlarmOpen(false)

--- a/src/components/common/notification/NotificationModal.tsx
+++ b/src/components/common/notification/NotificationModal.tsx
@@ -35,6 +35,7 @@ export default function NotificationModal({
     if (typeof window === 'undefined') return false
     return window.matchMedia('(min-width: 768px)').matches
   })
+  const prevIsDesktop = useRef<boolean>(isDesktop)
 
   // 모달이 열려있는 동안 배경 스크롤 잠금 + 진입 위치 초기화
   useEffect(() => {
@@ -61,6 +62,14 @@ export default function NotificationModal({
     mql.addEventListener('change', handle)
     return () => mql.removeEventListener('change', handle)
   }, [])
+
+  // PC에서 열린 상태로 모바일 사이즈로 전환되면 모달을 닫아 초기화
+  useEffect(() => {
+    if (prevIsDesktop.current && !isDesktop && onClose) {
+      onClose()
+    }
+    prevIsDesktop.current = isDesktop
+  }, [isDesktop, onClose])
 
   return (
     <motion.div

--- a/src/components/common/notification/NotificationModal.tsx
+++ b/src/components/common/notification/NotificationModal.tsx
@@ -10,11 +10,13 @@ import {
 import NotificationCard from './NotificationCard'
 
 type NotificationModalProps = {
+  isDesktop: boolean
   onClose?: () => void
   onAnimationComplete?: () => void
 }
 
 export default function NotificationModal({
+  isDesktop,
   onClose,
   onAnimationComplete,
 }: NotificationModalProps) {
@@ -31,11 +33,6 @@ export default function NotificationModal({
   const readCount = totalCount - unreadCount
   const controls = useAnimation()
   const originalOverflow = useRef<string>('')
-  const [isDesktop, setIsDesktop] = useState<boolean>(() => {
-    if (typeof window === 'undefined') return false
-    return window.matchMedia('(min-width: 768px)').matches
-  })
-  const prevIsDesktop = useRef<boolean>(isDesktop)
 
   // 모달이 열려있는 동안 배경 스크롤 잠금 + 진입 위치 초기화
   useEffect(() => {
@@ -52,28 +49,13 @@ export default function NotificationModal({
     { key: 'unread' as const, label: '읽지않음', count: unreadCount },
     { key: 'read' as const, label: '읽음', count: readCount },
   ]
-
-  // 데스크톱 여부 감지해 애니메이션/드래그 범위 분기
+  // 뷰포트 전환 시 보이지 않게 되는 걸 방지: 항상 보이는 위치/opacity로 맞춰줌
   useEffect(() => {
-    if (typeof window === 'undefined') return
-    const mql = window.matchMedia('(min-width: 768px)')
-    const handle = () => setIsDesktop(mql.matches)
-    handle()
-    mql.addEventListener('change', handle)
-    return () => mql.removeEventListener('change', handle)
-  }, [])
-
-  // PC에서 열린 상태로 모바일 사이즈로 전환되면 모달을 닫아 초기화
-  useEffect(() => {
-    if (prevIsDesktop.current && !isDesktop && onClose) {
-      onClose()
-    }
-    prevIsDesktop.current = isDesktop
-  }, [isDesktop, onClose])
+    controls.start({ y: 0, opacity: 1 })
+  }, [controls, isDesktop])
 
   return (
     <motion.div
-      key={isDesktop ? 'desktop' : 'mobile'}
       initial={isDesktop ? { y: 20, opacity: 0 } : { y: '100%', opacity: 0 }}
       animate={controls}
       exit={isDesktop ? { y: 20, opacity: 0 } : { y: '100%', opacity: 0 }}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,1 +1,1 @@
-//hooks
+export { default as useIsDesktop } from './useIsDesktop'

--- a/src/hooks/useIsDesktop.ts
+++ b/src/hooks/useIsDesktop.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * 간단한 viewport 감지 훅.
+ * - 초기값은 클라이언트 여부 확인 후 `(min-width: 768px)` 결과로 설정
+ * - 리사이즈 시 상태를 업데이트해서 반응형 분기에서 재사용
+ */
+export default function useIsDesktop() {
+  const [isDesktop, setIsDesktop] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return true
+    return window.matchMedia('(min-width: 768px)').matches
+  })
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const mql = window.matchMedia('(min-width: 768px)')
+    const handle = () => setIsDesktop(mql.matches)
+    handle()
+    mql.addEventListener('change', handle)
+    return () => mql.removeEventListener('change', handle)
+  }, [])
+
+  return isDesktop
+}


### PR DESCRIPTION
<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈
- closes #41

## 📑 구현 사항
- pc 에서 알림 오픈후 반응형 사이즈로 리사이즈시 백그라운드 모달 남아있는 현상 수정

## 🌀 어려웠던 점 / 고민했던 부분
-

## 📸 구현 이미지 (선택)
### 리펙토링 전

https://github.com/user-attachments/assets/7098b581-3df7-478a-8ba8-d85adc81a472

### 리펙토링 후

https://github.com/user-attachments/assets/3cbeb00a-578b-450d-aea2-54cb60e751b6





## ❇️ 코드 설명 (선택)
```
useEffect(() => {
    if (prevIsDesktop.current && !isDesktop && onClose) {
      onClose()
    }
    prevIsDesktop.current = isDesktop
  }, [isDesktop, onClose])
  ```
  
  Pc에서 알림 오픈후 모바일 사이즈로 전환시 알림 닫기 로직 구현

## 💬 리뷰 요청사항 (선택)
> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.
