### PR TITLE
Feat/40 posting manage UI(#40)

### DIFF
--- a/src/components/common/header/Header.tsx
+++ b/src/components/common/header/Header.tsx
@@ -18,7 +18,7 @@ function Header({ isSideBarOpen, setIsSideBarOpen }: HeaderProps) {
   }
 
   return (
-    <div className="w-full border-b border-solid border-[#E5E7EB]">
+    <div className="w-full border-b border-solid border-[#E5E7EB] bg-white">
       <div className="mx-auto flex h-[64px] max-w-[1440px] items-center justify-between px-8">
         {isSideBarOpen && <MobileModal setIsModalOpen={setIsSideBarOpen} />}
         <div className="flex items-center gap-[15px] md:hidden">

--- a/src/components/common/notification/NotificationCard.tsx
+++ b/src/components/common/notification/NotificationCard.tsx
@@ -1,12 +1,13 @@
-import type { AccentKey, AlarmIconType } from '@/types/alarm'
 import { getTypeIcon } from '@/helpers/icons'
+import type { AccentKey } from '@/types/alarm'
+import type { IconName } from '@/helpers/icons'
 
 type NotificationCardProps = {
   message: string
   date: string
   isRead?: boolean
   accent?: AccentKey
-  iconType?: AlarmIconType
+  iconType?: IconName
   onClick?: () => void
 }
 

--- a/src/components/postings/manage/ManageCard.tsx
+++ b/src/components/postings/manage/ManageCard.tsx
@@ -1,0 +1,99 @@
+import { Bookmark, Calendar, Eye, Pencil, Trash2, Users } from 'lucide-react'
+
+import type { ManageRecruitment } from '@/pages/postings/Manage'
+import { getTypeIcon } from '@/helpers/icons'
+import { Button } from '@/components/common'
+import { Badge } from '@/components/ui/badge'
+
+type ManageCardProps = {
+  posting: ManageRecruitment
+}
+
+export default function ManageCard({ posting }: ManageCardProps) {
+  return (
+    <div className="relative grid gap-4 rounded-lg border border-gray-200 bg-white p-4 md:grid-cols-[160px_1fr] md:items-start">
+      {/* 썸네일 */}
+      <div className="md:row-span-2">
+        <img
+          src={posting.thumbnailImgUrl}
+          alt={posting.title}
+          className="mx-auto h-[120px] max-w-40 rounded-md object-cover md:h-full"
+        />
+      </div>
+
+      {/* 내용 */}
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-wrap items-start justify-between gap-2">
+          <h3 className="text-base font-semibold text-gray-900">
+            {posting.title}
+          </h3>
+          <div className="flex items-center gap-3 text-xs text-gray-500">
+            <div className="flex items-center gap-1">
+              <Eye size={16} />
+              <span>{posting.viewsCount}</span>
+            </div>
+            <div className="flex items-center gap-1">
+              <Bookmark size={16} />
+              <span>{posting.bookmarkCount}</span>
+            </div>
+            <button className="text-gray-500 hover:text-gray-700">
+              <Pencil size={16} />
+            </button>
+            <button className="text-gray-500 hover:text-gray-700">
+              <Trash2 size={16} />
+            </button>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-2 text-sm text-gray-700">
+          <div className="flex items-center gap-2">
+            <Users size={16} />
+            <span>
+              모집 인원 : {posting.expectedHeadcount}명
+              {posting.isClosed && (
+                <span className="ml-2 rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600">
+                  마감
+                </span>
+              )}
+            </span>
+          </div>
+          <div className="flex items-center gap-2">
+            <Calendar size={16} />
+            <span>마감일 : {posting.closeAt.split('T')[0]}</span>
+          </div>
+          <div className="flex items-start gap-2">
+            <div className="flex flex-col gap-1">
+              <span className="text-gray-600">강의 목록 :</span>
+              {posting.lectures.length > 0 ? (
+                <div className="flex flex-col gap-1">
+                  {posting.lectures.map((lec) => (
+                    <span key={lec.id} className="text-gray-700">
+                      <i className="mr-2">·</i>
+                      {lec.title}
+                    </span>
+                  ))}
+                </div>
+              ) : (
+                <span>등록된 강의가 없습니다</span>
+              )}
+            </div>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {posting.tags.map((tag) => (
+              <Badge key={tag.id} variant={'primary'}>
+                {tag.name}
+              </Badge>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* 지원 내역 버튼 */}
+      <div className="md:absolute md:right-4 md:bottom-4 md:self-end">
+        <Button className="btn-active-blue h-12 w-full px-6 py-3 md:w-[150px]">
+          {getTypeIcon('total')} 지원 내역
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/postings/manage/ManageDashboard.tsx
+++ b/src/components/postings/manage/ManageDashboard.tsx
@@ -1,0 +1,57 @@
+import { getTypeIcon } from '@/helpers/icons'
+
+type ManageDashboardProps = {
+  totalCount: number
+  closedCount: number
+}
+
+export default function ManageDashboard({
+  totalCount,
+  closedCount,
+}: ManageDashboardProps) {
+  const open = totalCount - closedCount
+
+  const cards = [
+    {
+      key: 'total' as const,
+      label: '전체',
+      value: totalCount,
+      iconColor: 'accent-gray',
+    },
+    {
+      key: 'open' as const,
+      label: '모집중',
+      value: open,
+      iconColor: 'accent-green',
+    },
+    {
+      key: 'closed' as const,
+      label: '마감됨',
+      value: closedCount,
+      iconColor: 'accent-red',
+    },
+  ]
+
+  return (
+    <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+      {cards.map((card) => (
+        <div
+          key={card.label}
+          className="flex items-center gap-4 rounded-md border border-gray-200 bg-white p-[25px]"
+        >
+          <div
+            className={`flex h-12 w-12 items-center justify-center rounded-md ${card.iconColor}`}
+          >
+            {getTypeIcon(card.key)}
+          </div>
+          <div className="flex flex-col items-start">
+            <span className="text-xl font-semibold text-gray-900">
+              {card.value}
+            </span>
+            <span className="text-sm text-gray-500">{card.label}</span>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/components/postings/manage/ManageHeader.tsx
+++ b/src/components/postings/manage/ManageHeader.tsx
@@ -1,0 +1,29 @@
+import { Button } from '@/components/common'
+import { ArrowLeft, Plus } from 'lucide-react'
+
+export default function ManageHeader() {
+  return (
+    <div className="flex-between flex-col gap-8 md:flex-row">
+      <div className="flex-center mr-auto gap-4">
+        <Button
+          variant="ghost"
+          className="h-10 w-10 cursor-pointer rounded-full bg-gray-100 hover:bg-gray-200"
+        >
+          <ArrowLeft className="h-6 w-6" />
+        </Button>
+        <div>
+          <h2 className="text-3xl font-bold text-gray-900">공고 관리</h2>
+          <p className="text-base text-gray-500">
+            내가 등록한 스터디 구인 공고를 관리하세요
+          </p>
+        </div>
+      </div>
+      <Button
+        variant="primary"
+        className="mr-auto w-full cursor-pointer md:mr-0 md:w-fit"
+      >
+        <Plus className="h-6 w-6" /> 새 공고 작성하기
+      </Button>
+    </div>
+  )
+}

--- a/src/components/postings/manage/ManageList.tsx
+++ b/src/components/postings/manage/ManageList.tsx
@@ -1,0 +1,24 @@
+import ManageCard from './ManageCard'
+import type { ManageRecruitment } from '@/pages/postings/Manage'
+
+type ManageListProps = {
+  postings: ManageRecruitment[]
+}
+
+export default function ManageList({ postings }: ManageListProps) {
+  if (postings.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed border-gray-200 bg-white p-8 text-center text-sm text-gray-500">
+        등록된 공고가 없습니다.
+      </div>
+    )
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-4">
+      {postings.map((posting) => (
+        <ManageCard key={posting.uuid} posting={posting} />
+      ))}
+    </div>
+  )
+}

--- a/src/components/postings/manage/ManageSearch.tsx
+++ b/src/components/postings/manage/ManageSearch.tsx
@@ -1,0 +1,30 @@
+import Select from '@/components/common/Select'
+
+export default function ManageSearch() {
+  return (
+    <div className="flex-between flex-col gap-4 rounded-xl border border-gray-200 bg-white p-6 md:flex-row">
+      <div className="w-full md:w-1/2">
+        <Select
+          title="상태"
+          placeHolder="상태 선택"
+          data={[
+            { itemValue: 'all', itemText: '전체' },
+            { itemValue: 'open', itemText: '모집중' },
+            { itemValue: 'closed', itemText: '마감' },
+          ]}
+        />
+      </div>
+      <div className="w-full md:w-1/2">
+        <Select
+          title="정렬"
+          placeHolder="정렬 선택"
+          data={[
+            { itemValue: 'recent', itemText: '최신순' },
+            { itemValue: 'oldest', itemText: '오래된순' },
+            { itemValue: 'popular', itemText: '지원자 많은 순' },
+          ]}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/helpers/icons.tsx
+++ b/src/helpers/icons.tsx
@@ -3,25 +3,44 @@ import {
   CalendarDays,
   CalendarRange,
   Check,
+  Clock3,
+  FileText,
   FileSignature,
+  Megaphone,
   UserPlus,
   UsersRound,
   X,
 } from 'lucide-react'
 
-import type { AlarmIconType } from '@/types/alarm'
-import type { JSX } from 'react'
-
-const iconByType: Record<AlarmIconType, JSX.Element> = {
-  apply: <UserPlus size={16} />,
-  approved: <Check size={16} />,
-  rejected: <X size={16} />,
-  newMember: <UsersRound size={16} />,
-  studyEnd: <CalendarCheck size={16} />,
-  upcoming: <CalendarRange size={16} />,
-  today: <CalendarDays size={16} />,
-  note: <FileSignature size={16} />,
+// 도메인별 아이콘 그룹
+const notificationIcons = {
+  apply: UserPlus,
+  approved: Check,
+  rejected: X,
+  newMember: UsersRound,
+  studyEnd: CalendarCheck,
+  upcoming: CalendarRange,
+  today: CalendarDays,
+  note: FileSignature,
 }
 
-export const getTypeIcon = (iconType: AlarmIconType) =>
-  iconByType[iconType] ?? iconByType.apply
+const manageIcons = {
+  total: FileText,
+  open: Megaphone,
+  closed: Clock3,
+}
+
+// 평탄화된 맵 (어디서든 재사용)
+const iconByType = {
+  ...notificationIcons,
+  ...manageIcons,
+}
+
+export type NotificationIconName = keyof typeof notificationIcons
+export type ManageIconName = keyof typeof manageIcons
+export type IconName = keyof typeof iconByType
+
+export const getTypeIcon = (iconType: IconName, size = 16) => {
+  const IconComp = iconByType[iconType] ?? iconByType.apply
+  return <IconComp size={size} />
+}

--- a/src/index.css
+++ b/src/index.css
@@ -80,6 +80,10 @@
 }
 
 /* Accent helpers */
+.accent-gray {
+  background-color: var(--color-gray-100);
+  color: var(--color-gray-600);
+}
 .accent-blue {
   background-color: var(--color-accent-blue-bg);
   color: var(--color-accent-blue-text);

--- a/src/mappers/notification/mapper.ts
+++ b/src/mappers/notification/mapper.ts
@@ -1,4 +1,5 @@
 import type { AlarmItem } from '@/types/alarm'
+import type { IconName } from '@/helpers/icons'
 
 export type NotificationApiItem = {
   id: number
@@ -36,7 +37,7 @@ const typeToAccent = {
 } as const
 
 // 타입별 아이콘 지정
-const typeToIcon = {
+const typeToIcon: Record<string, IconName> = {
   STUDY_NOTE_CREATE: 'note',
   TODAY_SCHEDULE: 'today',
   UPCOMING_SCHEDULE: 'upcoming',

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,0 +1,4 @@
+export { default as Main } from './main'
+export { default as YeeunTest } from './YeeunTest'
+export { default as Courses } from './Courses'
+export { default as Manage } from './postings/Manage'

--- a/src/pages/postings/Manage.tsx
+++ b/src/pages/postings/Manage.tsx
@@ -1,0 +1,3 @@
+export default function Manage() {
+  return <div>내가 작성한 공고 목록</div>
+}

--- a/src/pages/postings/Manage.tsx
+++ b/src/pages/postings/Manage.tsx
@@ -1,3 +1,70 @@
+import ManageDashboard from '@/components/postings/manage/ManageDashboard'
+import ManageHeader from '@/components/postings/manage/ManageHeader'
+import ManageList from '@/components/postings/manage/ManageList'
+import ManageSearch from '@/components/postings/manage/ManageSearch'
+
+export type ManageRecruitment = {
+  uuid: string
+  title: string
+  thumbnailImgUrl: string
+  expectedHeadcount: number
+  closeAt: string
+  viewsCount: number
+  bookmarkCount: number
+  lectures: { id: number; title: string; instructor: string }[]
+  tags: { id: number; name: string }[]
+  isClosed: boolean
+}
+
+// API 응답을 매핑했다고 가정한 목업 데이터
+const MOCK_RECRUITMENTS: ManageRecruitment[] = [
+  {
+    uuid: 'b8dbd77f-cf73-4ef4-9914-4394d5ab366e',
+    title: '[급구] 파이썬 주 1회 스터디원 구합니다.',
+    thumbnailImgUrl:
+      'https://placehold.co/160x120/png?text=Recruitment+1',
+    expectedHeadcount: 10,
+    closeAt: '2025-11-20T00:00:05.875842+09:00',
+    viewsCount: 100,
+    bookmarkCount: 36,
+    lectures: [
+      { id: 1, title: '파이썬 마스터하기', instructor: '김한영' },
+      { id: 2, title: '알고리즘 실전', instructor: '홍길동' },
+    ],
+    tags: [
+      { id: 1, name: 'python' },
+      { id: 2, name: 'backend' },
+    ],
+    isClosed: false,
+  },
+  {
+    uuid: 'c1d2e3f4-cf73-4ef4-9914-4394d5ab366e',
+    title: '프론트엔드(React) 스터디 모집',
+    thumbnailImgUrl:
+      'https://placehold.co/160x120/png?text=Recruitment+2',
+    expectedHeadcount: 8,
+    closeAt: '2024-05-10T00:00:05.875842+09:00',
+    viewsCount: 240,
+    bookmarkCount: 58,
+    lectures: [{ id: 3, title: 'React 핵심', instructor: '이효리' }],
+    tags: [
+      { id: 3, name: 'frontend' },
+      { id: 4, name: 'react' },
+    ],
+    isClosed: true,
+  },
+]
+
 export default function Manage() {
-  return <div>내가 작성한 공고 목록</div>
+  return (
+    <div className="mx-auto flex max-w-5xl flex-col gap-6 px-4 py-6">
+      <ManageHeader />
+      <ManageDashboard
+        totalCount={MOCK_RECRUITMENTS.length}
+        closedCount={MOCK_RECRUITMENTS.filter((r) => r.isClosed).length}
+      />
+      <ManageSearch />
+      <ManageList postings={MOCK_RECRUITMENTS} />
+    </div>
+  )
 }

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -1,7 +1,5 @@
 import Layout from '@/components/common/layout/Layout'
-import Courses from '@/pages/Courses'
-import Main from '@/pages/main'
-import YeeunTest from '@/pages/YeeunTest'
+import { Courses, Main, Manage, YeeunTest } from '@/pages'
 import { Route, Routes } from 'react-router'
 function AppRoutes() {
   return (
@@ -11,6 +9,7 @@ function AppRoutes() {
         <Route index element={<Main />} />
         <Route path="/courses" element={<Courses></Courses>}></Route>
         <Route path="/yeeun" element={<YeeunTest></YeeunTest>}></Route>
+        <Route path="/posting/manage" element={<Manage />}></Route>
       </Route>
     </Routes>
   )

--- a/src/types/alarm.ts
+++ b/src/types/alarm.ts
@@ -8,15 +8,7 @@ export type AccentKey =
   | 'pink'
   | 'teal'
 
-export type AlarmIconType =
-  | 'apply'
-  | 'approved'
-  | 'rejected'
-  | 'newMember'
-  | 'studyEnd'
-  | 'upcoming'
-  | 'today'
-  | 'note'
+import type { IconName } from '@/helpers/icons'
 
 export type AlarmItem = {
   id: string
@@ -24,5 +16,5 @@ export type AlarmItem = {
   date: string
   isRead: boolean
   accent: AccentKey
-  iconType: AlarmIconType
+  iconType: IconName
 }


### PR DESCRIPTION
<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #40

## 📑 구현 사항

- 내 공고 목록 UI 구현
- icon 헬퍼 함수 의존성 제거

## 🌀 어려웠던 점 / 고민했던 부분
-  헬퍼함수의 확장성과 의존성을 제거하는대 고민을 많이 하게됬다..

## 📸 구현 이미지
<img width="920" height="748" alt="image" src="https://github.com/user-attachments/assets/b9064044-0f3f-495c-9a05-42c4eceddabc" />
<img width="995" height="2111" alt="image" src="https://github.com/user-attachments/assets/b18a4c34-a549-4686-be22-43185ecf4a57" />


## ❇️ 코드 설명
<img width="1252" height="1012" alt="1111" src="https://github.com/user-attachments/assets/4d93c638-b2e8-4aca-b419-c99121755136" />

도메인별 icon 객체 선언 후 iconByType으로 평탄화
아이콘 사용 위치에서 쓸수있게 type export 및 getTypeIcon 함수 호출하여 아이콘 사용및 사이즈 조절가능

예시: getTypeIcon('total', 16) 

## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1.
