### PR TITLE
feat: Intersection Observer와 쿼리연동하여 무한스크롤 구현 (#47)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-icons": "^5.5.0",
+        "react-intersection-observer": "^10.0.0",
         "react-router": "^7.6.2",
         "react-toastify": "^11.0.5",
         "zustand": "^5.0.5"
@@ -5836,6 +5837,21 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "*"
+      }
+    },
+    "node_modules/react-intersection-observer": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-10.0.0.tgz",
+      "integrity": "sha512-JJRgcnFQoVXmbE5+GXr1OS1NDD1gHk0HyfpLcRf0575IbJz+io8yzs4mWVlfaqOQq1FiVjLvuYAdEEcrrCfveg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-icons": "^5.5.0",
+    "react-intersection-observer": "^10.0.0",
     "react-router": "^7.6.2",
     "react-toastify": "^11.0.5",
     "zustand": "^5.0.5"

--- a/src/components/lecture/LectureList.tsx
+++ b/src/components/lecture/LectureList.tsx
@@ -35,10 +35,7 @@ export default function LectureList() {
       </div>
       {/* 페이지 로드하고, 더이상 보여줄 페이지가 없다면? 없다는 텍스트 노출 */}
       {!hasNextPage ? (
-        <div
-          className="flex-center mt-12 h-12 rounded-full bg-gray-200 text-center text-white"
-          ref={ref}
-        >
+        <div className="flex-center mt-12 h-12 rounded-full bg-gray-200 text-center text-white">
           더 이상 강의가 없습니다.
         </div>
       ) : (

--- a/src/components/lecture/LectureList.tsx
+++ b/src/components/lecture/LectureList.tsx
@@ -1,20 +1,54 @@
 import useGetLectures from '@/hooks/quries/useGetLecture'
-import React from 'react'
+import React, { useEffect } from 'react'
+import { useInView } from 'react-intersection-observer'
 import LectureCard from './LectureCard'
 
 export default function LectureList() {
-  const { data } = useGetLectures()
-  console.log(data)
+  //data 불러오기
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useGetLectures()
+
+  //무한스크롤
+  const { ref, inView } = useInView({
+    threshold: 0,
+    rootMargin: '50px',
+  })
+
+  //inView 변할 때 마다, 다음페이지 호출
+  useEffect(() => {
+    if (inView && hasNextPage && !isFetchingNextPage) {
+      fetchNextPage()
+    }
+    console.log('화면에 있니???', inView)
+  }, [inView])
 
   return (
-    <div className="grid w-full gap-3 md:grid-cols-2 lg:grid-cols-3">
-      {data?.pages.map((page, pageIndex) => (
-        <React.Fragment key={pageIndex}>
-          {page.results.map((lecture) => (
-            <LectureCard key={lecture.id} {...lecture} />
-          ))}
-        </React.Fragment>
-      ))}
-    </div>
+    <>
+      <div className="grid w-full gap-3 md:grid-cols-2 lg:grid-cols-3">
+        {data?.pages.map((page, pageIndex) => (
+          <React.Fragment key={pageIndex}>
+            {page.results.map((lecture) => (
+              <LectureCard key={lecture.id} {...lecture} />
+            ))}
+          </React.Fragment>
+        ))}
+      </div>
+      {/* 페이지 로드하고, 더이상 보여줄 페이지가 없다면? 없다는 텍스트 노출 */}
+      {!hasNextPage ? (
+        <div
+          className="flex-center mt-12 h-12 rounded-full bg-gray-200 text-center text-white"
+          ref={ref}
+        >
+          더 이상 강의가 없습니다.
+        </div>
+      ) : (
+        <div
+          className="bg-primary-500 flex-center mt-12 h-12 rounded-full text-center text-white"
+          ref={ref}
+        >
+          더많은 공고 보기
+        </div>
+      )}
+    </>
   )
 }

--- a/src/components/lecture/LectureList.tsx
+++ b/src/components/lecture/LectureList.tsx
@@ -46,7 +46,7 @@ export default function LectureList() {
           className="bg-primary-500 flex-center mt-12 h-12 rounded-full text-center text-white"
           ref={ref}
         >
-          더많은 공고 보기
+          더많은 강의 보기
         </div>
       )}
     </>

--- a/src/components/lecture/LectureList.tsx
+++ b/src/components/lecture/LectureList.tsx
@@ -35,12 +35,12 @@ export default function LectureList() {
       </div>
       {/* 페이지 로드하고, 더이상 보여줄 페이지가 없다면? 없다는 텍스트 노출 */}
       {!hasNextPage ? (
-        <div className="flex-center mt-12 h-12 rounded-full bg-gray-200 text-center text-white">
+        <div className="flex-center mt-12 h-12 rounded-md bg-gray-400 text-center text-white">
           더 이상 강의가 없습니다.
         </div>
       ) : (
         <div
-          className="bg-primary-500 flex-center mt-12 h-12 rounded-full text-center text-white"
+          className="bg-primary-500 flex-center mt-12 h-12 rounded-md text-center text-white"
           ref={ref}
         >
           더많은 강의 보기

--- a/src/mocks/browser.ts
+++ b/src/mocks/browser.ts
@@ -1,5 +1,4 @@
 import { setupWorker } from 'msw/browser'
 import { handlers } from './handlers'
-import { lectureHandlers } from './handlers/lectures/lectureHandlers'
 
-export const worker = setupWorker(...handlers, ...lectureHandlers)
+export const worker = setupWorker(...handlers)

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,6 +1,7 @@
 import { http, HttpResponse } from 'msw'
-import { userInformationHandler } from './handlers/user'
+import { lectureHandlers } from './handlers/lectures/lectureHandlers'
 import { notificationHandlers } from './handlers/notification'
+import { userInformationHandler } from './handlers/user'
 
 type User = { id: number; name: string; email: string }
 
@@ -14,6 +15,8 @@ export const handlers = [
   ...userInformationHandler,
   // 알림 핸들러
   ...notificationHandlers,
+  // 강의목록 핸들러
+  ...lectureHandlers,
 
   http.get('/api/users', () => {
     return HttpResponse.json(users)

--- a/src/pages/Courses.tsx
+++ b/src/pages/Courses.tsx
@@ -21,7 +21,7 @@ export default function Courses() {
           description="로그인하시면 관심 분야를 바탕으로 맞춤형 강의"
         ></GuestRecommendSection>
       </section>
-      <section className="courses_filter flex gap-4 rounded-md border-2 border-gray-200 bg-white p-6">
+      <section className="courses_filter flex gap-4 rounded-md border border-gray-200 bg-white p-6">
         <Input prefix={<Search />} className="h-[38px]"></Input>
         <Select
           icon={<Folder />}
@@ -36,7 +36,7 @@ export default function Courses() {
           onValueChange={(e) => console.log(e)} //디버깅
         ></Select>
       </section>
-      <section className="courses_cardlist border-2">
+      <section className="courses_cardlist">
         <LectureList></LectureList>
       </section>
     </div>


### PR DESCRIPTION
<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #47

## 📑 구현 사항

- @soohyun-bae 조언대로 핸들러 정리했습니다.
- Intersection Observer 구현 ( 라이브러리 설치 `npm install react-intersection-observer --save` )
- 감지하는 영역을 div 태그로 박스 요소 만들었습니다. 

## 🌀 어려웠던 점 / 고민했던 부분

- useInView 의 반환값이 entry 가 속해있었으나, 우리 코드에선 필요없었다. 
- 왜 필요없는지 ai한테 물어보았고, 결론은 '사용안함' 이였다. 
- `useInView`의 옵션에서 설정이 가능하기 때문에 `entry` 는 필요없다! 

### ⚙️ entry가 필요한 경우
    - 진행률 표시 (intersection ratio 활용)
    - 복잡한 애니메이션 (위치 기반)
    - 특수한 스크롤 이벤트 처리
    - 일반적인 무한 스크롤은 `inView` 만 사용하면 된다고 한다. 
    

## 📸 구현 이미지
### 더많은 강의목록 확인하기 (사실 이건 보일 확률 적긴함 )
<img width="1342" height="805" alt="스크린샷 2025-12-03 오후 6 04 29" src="https://github.com/user-attachments/assets/8f3aaa33-71c7-4b66-9bc9-37e71fb9a783" />


### 더이상 강의가 읎어요 !
<img width="1342" height="730" alt="스크린샷 2025-12-03 오후 5 11 37" src="https://github.com/user-attachments/assets/71c634e8-2f1d-4597-8b7f-a9848bb65bbf" />

### 무한스크롤
![무한스크롤](https://github.com/user-attachments/assets/296c749b-0029-48a7-a6c8-6e9b32e7e2da)


---

## ❇️ 코드 설명

### `useInView` 훅 사용하기

- 스크롤 위치 감지하여 자동으로 다음 페이지 로직
- 기본 사용법은 아래와 같다.

```tsx
  import { useInView } from 'react-intersection-observer'
  const { ref, inView,entry } = useInView({
    threshold: 0,
    rootMargin: '50px',
  })

```

- **`ref`** : 필요한 `node element` 를 감지함 (`<h1 ref={ref} >` ) 처럼 사용
- **`inView` :** `boolean` 형태로, `ref`로 설정한 node가 화면에 보이면? `inView`는 true로 바뀜.
- **`entry`**: IntersectionObserverEntry 객체 (상세 정보)
**Options**

**`threshold`** (0~1)

- 요소가 얼마나 보일 때 감지할지
- `0`: 1px만 보여도 감지
- `1`: 100% 보여야 감지
- 무한스크롤은 보통 `0` 또는 `0.1` 사용

**`rootMargin`** (CSS margin 문법)

- 감지 영역 확장/축소
- `'200px'`: 뷰포트 기준 200px 전에 미리 감지
- 무한스크롤에서 미리 로딩할 때 유용

**`triggerOnce`** (boolean)

- `true`: 한 번만 감지 후 해제
- 무한스크롤은 `false` (기본값) 사용

---

### useEffect훅 구현

- 이제 **`inView`** 의 true이면 api호출하는 함수를 만들 것 (  `useEffect(() => {}, [inView])` )
- 불러오는 api는 `fetchNextPage` 를 통해서 다음 번호로 불러오기

```tsx
  //inView 변할 때 마다, 다음페이지 호출
  useEffect(() => {
    fetchNextPage()
    console.log('화면에 있니???', inView)
  }, [inView])
```

- 근데 여기서 마무리하면 스크롤 이동하면서 , 해당 함수가 계속 호출이 되겠지
- 이때 조건문을 한번 걸어줘야한다.

```tsx
useEffect(() => {
  if (inView && hasNextPage && !isFetchingNextPage) {
    fetchNextPage();
  }
}, [inView, hasNextPage, isFetchingNextPage, fetchNextPage]);
```

- **`hasNextPage`** : 다음 페이지 존재 여부 (boolean)
- **`isFetchingNextPage`** : 현재 다음 페이지를 로딩 중인지 (boolean)
    - 중복 요청 방지용으로 활용 할 수 있다.
    - 예를들어, **아직 로딩 중인데** 감지 요소가 계속 뷰포트에 있는 경우?
    - 불필요한 호출이 계속 있을 수 있음
    - 이때, **`isFetchingNextPage`** 가 로딩중이 아닌 경우에만 데이터 받아올 수 있도록 조건을 넣어야한다.


## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1. 감지영역받는 박스 디자인이 괜찮은지 확인해주세요 (`src/components/lecture/LectureList.tsx` 37~50번째)
2. 무한 스크롤에서는 필요없지만,  `const { entry } = useInView` 에서 `entry` 가 활용되는 경우가 있을까요? 궁금하네요 
