### PR TITLE
feat: 할인율 계산 및 별점 아이콘 동적 구현 (#62)

### DIFF
--- a/src/components/lecture/LectureCard.tsx
+++ b/src/components/lecture/LectureCard.tsx
@@ -45,7 +45,6 @@ export default function LectureCard(lectures: Lecture) {
         <CardAction className="absolute z-10 justify-between px-3 py-3">
           <div className="top-2 flex flex-col gap-2">
             <Badge variant={'platform'}>{platform}</Badge>
-            {/* 할인율계산은 추후 헬퍼함수를 통해 구현할 예정 */}
             <Badge variant={'discount'}>
               {getDiscount(discounted_price, original_price)}% 할인
             </Badge>

--- a/src/components/lecture/LectureCard.tsx
+++ b/src/components/lecture/LectureCard.tsx
@@ -7,11 +7,12 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
+import { getDiscount } from '@/helpers/getDiscount'
+import getRatingStarsIcon from '@/helpers/getRatingStarsIcon'
 import { LectureLevel } from '@/mappers/lectures/lecture'
 import type { Lecture } from '@/types/lecture'
 import { Bookmark, Plus } from 'lucide-react'
 import { useEffect, useState } from 'react'
-import { FaRegStar, FaStar, FaStarHalfAlt } from 'react-icons/fa'
 import { Button } from '../common/Button'
 import { Badge } from '../ui/badge'
 import LectureReviewCard from './LectureReviewCard'
@@ -45,7 +46,9 @@ export default function LectureCard(lectures: Lecture) {
           <div className="top-2 flex flex-col gap-2">
             <Badge variant={'platform'}>{platform}</Badge>
             {/* 할인율계산은 추후 헬퍼함수를 통해 구현할 예정 */}
-            <Badge variant={'discount'}>32% 할인</Badge>
+            <Badge variant={'discount'}>
+              {getDiscount(discounted_price, original_price)}% 할인
+            </Badge>
           </div>
           <Button
             variant="outline"
@@ -77,16 +80,7 @@ export default function LectureCard(lectures: Lecture) {
         </div>
         <CardTitle>{title}</CardTitle>
         <CardDescription>{instructor}</CardDescription>
-        <div className="flex items-center gap-2">
-          <div className="star-rating flex">
-            <FaStar size={20} fill="#FACC15"></FaStar>
-            <FaStar size={20} fill="#FACC15"></FaStar>
-            <FaStar size={20} fill="#FACC15"></FaStar>
-            <FaStarHalfAlt size={20} fill="#FACC15"></FaStarHalfAlt>
-            <FaRegStar size={20} fill="#FACC15" />
-          </div>
-          <p className="text-sm font-medium">{average_rating}</p>
-        </div>
+        {getRatingStarsIcon(average_rating)}
         <div className="Card-Content-price flex items-center gap-2">
           <h4>₩{discounted_price.toLocaleString('ko-KR')}</h4>
           <h6 className="text-sm text-gray-400 line-through">

--- a/src/components/lecture/LectureReviewCard.tsx
+++ b/src/components/lecture/LectureReviewCard.tsx
@@ -1,7 +1,7 @@
 import { getDiscount } from '@/helpers/getDiscount'
+import getRatingStarsIcon from '@/helpers/getRatingStarsIcon'
 import { LectureLevel } from '@/mappers/lectures/lecture'
 import type { Lecture } from '@/types/lecture'
-import { FaRegStar, FaStar, FaStarHalfAlt } from 'react-icons/fa'
 import { Dialog, DialogContent } from '../common/Modal'
 import { Badge } from '../ui/badge'
 import {
@@ -68,16 +68,7 @@ export default function LectureReviewCard({
             </div>
             <CardTitle>{title}</CardTitle>
             <CardDescription>{instructor}</CardDescription>
-            <div className="flex items-center gap-2">
-              <div className="star-rating flex">
-                <FaStar size={20} fill="#FACC15"></FaStar>
-                <FaStar size={20} fill="#FACC15"></FaStar>
-                <FaStar size={20} fill="#FACC15"></FaStar>
-                <FaStarHalfAlt size={20} fill="#FACC15"></FaStarHalfAlt>
-                <FaRegStar size={20} fill="#FACC15" />
-              </div>
-              <p className="text-sm font-medium">{average_rating}</p>
-            </div>
+            {getRatingStarsIcon(average_rating)}
             <div className="Card-Content-price flex items-center gap-2">
               <h4>₩{discounted_price.toLocaleString('ko-KR')}</h4>
               <h6 className="text-sm text-gray-400 line-through">
@@ -87,25 +78,23 @@ export default function LectureReviewCard({
           </CardContent>
           <CardFooter className="flex w-full flex-col items-start gap-2">
             <CardTitle className="mb-2 text-left">리뷰보기</CardTitle>
-            {reviews.map((i) => (
-              <Item key={i.id} className="w-full">
+            {reviews.length === 0 ? (
+              <Item className="w-full">
                 <ItemContent>
-                  <ItemTitle>
-                    <div className="flex items-center gap-2">
-                      <div className="star-rating flex">
-                        <FaStar size={20} fill="#FACC15"></FaStar>
-                        <FaStar size={20} fill="#FACC15"></FaStar>
-                        <FaStar size={20} fill="#FACC15"></FaStar>
-                        <FaStarHalfAlt size={20} fill="#FACC15"></FaStarHalfAlt>
-                        <FaRegStar size={20} fill="#FACC15" />
-                      </div>
-                      {i.rating}
-                    </div>
-                  </ItemTitle>
-                  <ItemDescription>{i.content}</ItemDescription>
+                  <ItemTitle>{getRatingStarsIcon(0)}</ItemTitle>
+                  <ItemDescription>리뷰가 없습니다</ItemDescription>
                 </ItemContent>
               </Item>
-            ))}
+            ) : (
+              reviews.map((i) => (
+                <Item key={i.id} className="w-full">
+                  <ItemContent>
+                    <ItemTitle>{getRatingStarsIcon(i.rating)}</ItemTitle>
+                    <ItemDescription>{i.content}</ItemDescription>
+                  </ItemContent>
+                </Item>
+              ))
+            )}
           </CardFooter>
         </Card>
       </DialogContent>

--- a/src/components/lecture/LectureReviewCard.tsx
+++ b/src/components/lecture/LectureReviewCard.tsx
@@ -1,3 +1,4 @@
+import { getDiscount } from '@/helpers/getDiscount'
 import { LectureLevel } from '@/mappers/lectures/lecture'
 import type { Lecture } from '@/types/lecture'
 import { FaRegStar, FaStar, FaStarHalfAlt } from 'react-icons/fa'
@@ -45,7 +46,9 @@ export default function LectureReviewCard({
             <CardAction className="absolute z-10 justify-between px-3 py-3">
               <div className="top-2 flex flex-col gap-2">
                 <Badge variant={'platform'}>{platform}</Badge>
-                <Badge variant={'discount'}>32% 할인</Badge>
+                <Badge variant={'discount'}>
+                  {getDiscount(discounted_price, original_price)}% 할인
+                </Badge>
               </div>
             </CardAction>
 

--- a/src/helpers/getDiscount.ts
+++ b/src/helpers/getDiscount.ts
@@ -1,0 +1,3 @@
+export function getDiscount(discounted_price: number, original_price: number) {
+  return Math.floor((discounted_price / original_price) * 100)
+}

--- a/src/helpers/getDiscount.ts
+++ b/src/helpers/getDiscount.ts
@@ -1,3 +1,5 @@
 export function getDiscount(discounted_price: number, original_price: number) {
-  return Math.floor((discounted_price / original_price) * 100)
+  return Math.floor(
+    ((original_price - discounted_price) / original_price) * 100
+  )
 }

--- a/src/helpers/getRatingStarsIcon.tsx
+++ b/src/helpers/getRatingStarsIcon.tsx
@@ -1,0 +1,54 @@
+import { FaRegStar, FaStar, FaStarHalfAlt } from 'react-icons/fa'
+
+// //반올림,올림,내림 공식
+// function decimalAdjust(type: string, value: number, exp: number) {
+//   if (exp % 1 !== 0 || Number.isNaN(value)) {
+//     return NaN
+//   } else if (exp === 0) {
+//     return Math[type](value)
+//   }
+//   const [magnitude, exponent = 0] = value.toString().split('e')
+//   const adjustedValue = Math[type](`${magnitude}e${exponent - exp}`)
+//   // 뒤로 이동
+//   const [newMagnitude, newExponent = 0] = adjustedValue.toString().split('e')
+//   return Number(`${newMagnitude}e${+newExponent + exp}`)
+// }
+
+// // 소수점 첫번째 자리에서 내림하는 로직
+// const floor10 = (value: number, exp: number) =>
+//   decimalAdjust('floor', value, exp)
+// console.log(floor10(4.95, -1)) //4.9 별 4개반
+// console.log(floor10(2.37, -1)) //2.3 별 2개
+
+export default function getRatingStarsIcon(average_rating: number) {
+  //별점은 5점 만점 , 아이콘 5개 있어야함
+  const filledStarCount = Math.floor(average_rating) // 4.59 -> 4
+  const hasHalfStar = average_rating - filledStarCount >= 0.5
+  const emptyStar = hasHalfStar ? 5 - 1 - filledStarCount : 5 - filledStarCount
+
+  return (
+    <div className="flex items-center gap-2">
+      <div className="star-rating flex">
+        {[...Array(filledStarCount)].map((_, idx) => (
+          <FaStar size={20} fill="#FACC15" key={idx}></FaStar>
+        ))}
+        {/* 왜 안되는걸까 다시 확ㅇ니해봐야징
+                {hasHalfStar ?? (
+          <FaStarHalfAlt size={20} fill="#FACC15"></FaStarHalfAlt>
+        )
+          }
+
+        */}
+        {hasHalfStar ? (
+          <FaStarHalfAlt size={20} fill="#FACC15"></FaStarHalfAlt>
+        ) : (
+          ''
+        )}
+        {[...Array(emptyStar)].map((_, idx) => (
+          <FaRegStar size={20} fill="#FACC15" key={idx} />
+        ))}
+      </div>
+      <p className="text-sm font-medium">{average_rating}</p>
+    </div>
+  )
+}

--- a/src/helpers/getRatingStarsIcon.tsx
+++ b/src/helpers/getRatingStarsIcon.tsx
@@ -32,17 +32,9 @@ export default function getRatingStarsIcon(average_rating: number) {
         {[...Array(filledStarCount)].map((_, idx) => (
           <FaStar size={20} fill="#FACC15" key={idx}></FaStar>
         ))}
-        {/* 왜 안되는걸까 다시 확ㅇ니해봐야징
-                {hasHalfStar ?? (
+        {/*  hasHalfStar True이면 */}
+        {hasHalfStar && (
           <FaStarHalfAlt size={20} fill="#FACC15"></FaStarHalfAlt>
-        )
-          }
-
-        */}
-        {hasHalfStar ? (
-          <FaStarHalfAlt size={20} fill="#FACC15"></FaStarHalfAlt>
-        ) : (
-          ''
         )}
         {[...Array(emptyStar)].map((_, idx) => (
           <FaRegStar size={20} fill="#FACC15" key={idx} />

--- a/src/mocks/data/lectureList.json
+++ b/src/mocks/data/lectureList.json
@@ -12,7 +12,7 @@
       "discounted_price": 87000,
       "difficulty": "EASY",
       "thumbnail_img_url": "https://picsum.photos/seed/1/400/240",
-      "average_rating": "4.01",
+      "average_rating": 0,
       "platform": "UDEMY",
       "url_link": "https://jsonplaceholder.typicode.com/todos/203",
       "categories": [
@@ -29,26 +29,7 @@
           "updated_at": "2012-02-22T00:00:00+09:00"
         }
       ],
-      "reviews": [
-        {
-          "id": 32,
-          "rating": 5,
-          "content": "기초부터 차근차근 설명해주셔서 초보자도 따라가기 쉬웠어요. 실습 예제도 유용했습니다!",
-          "created_at": "2024-11-15T00:00:00+09:00"
-        },
-        {
-          "id": 23,
-          "rating": 4,
-          "content": "전반적으로 만족스러운 강의입니다. 다만 좀 더 심화 내용이 있었으면 좋겠어요.",
-          "created_at": "2024-10-21T00:00:00+09:00"
-        },
-        {
-          "id": 55,
-          "rating": 5,
-          "content": "실무에 바로 적용할 수 있는 내용들이라 정말 유익했습니다. 강력 추천!",
-          "created_at": "2024-09-11T00:00:00+09:00"
-        }
-      ]
+      "reviews": []
     },
     {
       "id": 569,
@@ -59,7 +40,7 @@
       "discounted_price": 139000,
       "difficulty": "HARD",
       "thumbnail_img_url": "https://picsum.photos/seed/2/400/240",
-      "average_rating": "2.76",
+      "average_rating": 2.76,
       "platform": "INFLEARN",
       "url_link": "https://jsonplaceholder.typicode.com/todos/569",
       "categories": [
@@ -100,7 +81,7 @@
       "discounted_price": 99000,
       "difficulty": "NORMAL",
       "thumbnail_img_url": "https://picsum.photos/seed/3/400/240",
-      "average_rating": "4.20",
+      "average_rating": 4.2,
       "platform": "INFLEARN",
       "url_link": "https://jsonplaceholder.typicode.com/todos/931",
       "categories": [
@@ -153,7 +134,7 @@
       "discounted_price": 169000,
       "difficulty": "HARD",
       "thumbnail_img_url": "https://picsum.photos/seed/4/400/240",
-      "average_rating": "1.76",
+      "average_rating": 1.76,
       "platform": "UDEMY",
       "url_link": "https://jsonplaceholder.typicode.com/todos/485",
       "categories": [
@@ -194,7 +175,7 @@
       "discounted_price": 69000,
       "difficulty": "EASY",
       "thumbnail_img_url": "https://picsum.photos/seed/5/400/240",
-      "average_rating": "1.45",
+      "average_rating": 1.45,
       "platform": "UDEMY",
       "url_link": "https://jsonplaceholder.typicode.com/todos/784",
       "categories": [
@@ -229,7 +210,7 @@
       "discounted_price": 119000,
       "difficulty": "EASY",
       "thumbnail_img_url": "https://picsum.photos/seed/6/400/240",
-      "average_rating": "1.04",
+      "average_rating": 1.04,
       "platform": "INFLEARN",
       "url_link": "https://jsonplaceholder.typicode.com/todos/578",
       "categories": [
@@ -270,7 +251,7 @@
       "discounted_price": 109000,
       "difficulty": "EASY",
       "thumbnail_img_url": "https://picsum.photos/seed/7/400/240",
-      "average_rating": "2.07",
+      "average_rating": 2.07,
       "platform": "UDEMY",
       "url_link": "https://jsonplaceholder.typicode.com/todos/307",
       "categories": [
@@ -317,7 +298,7 @@
       "discounted_price": 59000,
       "difficulty": "EASY",
       "thumbnail_img_url": "https://picsum.photos/seed/8/400/240",
-      "average_rating": "2.76",
+      "average_rating": 2.76,
       "platform": "INFLEARN",
       "url_link": "https://jsonplaceholder.typicode.com/todos/296",
       "categories": [
@@ -370,7 +351,7 @@
       "discounted_price": 149000,
       "difficulty": "HARD",
       "thumbnail_img_url": "https://picsum.photos/seed/9/400/240",
-      "average_rating": "4.98",
+      "average_rating": 4.98,
       "platform": "INFLEARN",
       "url_link": "https://jsonplaceholder.typicode.com/todos/183",
       "categories": [
@@ -417,7 +398,7 @@
       "discounted_price": 129000,
       "difficulty": "HARD",
       "thumbnail_img_url": "https://picsum.photos/seed/10/400/240",
-      "average_rating": "3.18",
+      "average_rating": 3.18,
       "platform": "INFLEARN",
       "url_link": "https://jsonplaceholder.typicode.com/todos/410",
       "categories": [

--- a/src/mocks/handlers/lectures/lectureHandlers.ts
+++ b/src/mocks/handlers/lectures/lectureHandlers.ts
@@ -30,10 +30,12 @@ export const lectureHandlers = [
     const sort = url.searchParams.get('sort')
     const category = url.searchParams.get('category')
     let filtered = [...allLectures]
-    // 1. 검색 필터
+
+    // 1. 검색 필드
     if (search) {
-      filtered = filtered.filter((lecture) =>
-        lecture.title.toLowerCase().includes(search.toLowerCase())
+      filtered = filtered.filter(
+        (lecture) =>
+          lecture.title.includes(search) || lecture.instructor.includes(search)
       )
     }
 
@@ -57,9 +59,9 @@ export const lectureHandlers = [
           case 'high_price':
             return b.discounted_price - a.discounted_price
           case 'high_rating':
-            return parseFloat(b.average_rating) - parseFloat(a.average_rating)
+            return b.average_rating - a.average_rating
           case 'low_rating':
-            return parseFloat(a.average_rating) - parseFloat(b.average_rating)
+            return a.average_rating - b.average_rating
           default:
             return 0
         }

--- a/src/types/lecture.ts
+++ b/src/types/lecture.ts
@@ -6,7 +6,7 @@ export type Lecture = {
   discounted_price: number //디폴트가격으로 설정됨
   difficulty: 'EASY' | 'NORMAL' | 'HARD' //난이도,UI설정은 아직 미정
   thumbnail_img_url: string
-  average_rating: string
+  average_rating: number
   platform: 'UDEMY' | 'INFLEARN'
   url_link: string
   categories: Category[]


### PR DESCRIPTION
<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #62 

## 📑 구현 사항

- 강의 카드에서 사용하는 유틸리티 함수들을 헬퍼로 분리하였습니다. ( 할인율 및 별점아이콘)
- 할인율 계산 로직을 `getDiscount` 헬퍼 함수로 구현
- 별점 표시 로직을 `getRatingStarsIcon` 헬퍼 함수로 구현
- average_rating 타입을 string에서 number로 수정

## 🌀 어려웠던 점 / 고민했던 부분
### nullish coalescing operator
```tsx
{hasHalfStar ?? (
  <FaStarHalfAlt size={20} fill="#FACC15"></FaStarHalfAlt>
)}
```
> `??` 는 값이 `null` 또는 `undefined`일 때만 오른쪽 값을 반환하는 rjt
- 조건처리시  `??` 도  `false` 를 포함하는 건줄알고 처음에 이 코드로 작성하였다! 
- 그러나 원하는 값이 안나왔고, `nullish` 연산자는 `boolean`과는 상관관계가 없다는걸 이번시간에 다시한번 배우게 되었다. 
- boolean으로 분기처리하여 컴포넌트 띄우게 하려면 `&&`를 사용해야한다. 

### 동적 별 아이콘 계산에서 고민했던 부분
- 별점 표시 로직에서 소수점을 기준으로 별을 동적으로 표현하는 방법을 고민했습니다.
- 예를 들어 평점이 `4.78`인 경우, 소수점 첫째 자리 기준으로 **0.5 이상이면 반별, 미만이면 빈별**로 표시하려 했습니다.
- 처음에는 빈 배열에 값을 채워서 매핑하는 방식을 시도했습니다:
  - `0`: 빈 별
  - `1`: 반 별  
  - `2`: 꽉 찬 별

### 최종 접근 방법
공통 패턴을 발견하여 다음과 같이 구현했습니다:

1. **꽉 찬 별 개수**: `Math.floor(평점)` - 정수 부분만 추출
2. **반 별 여부**: `(평점 - 정수부분) >= 0.5` 로 boolean 판단
3. **빈 별 개수**: `5 - 꽉찬별 - (반별 있으면 1, 없으면 0)`

**예시:**
- `4.98` → 꽉찬별 4개 + 반별 1개 (4.98 - 4 = 0.98 ≥ 0.5)
- `3.29` → 꽉찬별 3개 + 빈별 2개 (3.29 - 3 = 0.29 < 0.5)
- `4.50` → 꽉찬별 4개 + 반별 1개 (4.50 - 4 = 0.50 ≥ 0.5)

## 📸 구현 이미지
### 할인율 및 평점 아이콘
<img width="1109" height="795" alt="스크린샷 2025-12-10 오후 7 32 37" src="https://github.com/user-attachments/assets/1ec4511a-3284-4a5c-aed7-894a578f95ad" />


### 평점 및 리뷰 없음 
<img width="1109" height="795" alt="스크린샷 2025-12-10 오후 7 31 31" src="https://github.com/user-attachments/assets/3b47ebd0-4b32-4883-9002-efe646b5f7e5" />


## ❇️ 코드 설명
### 할인율 계산로직 
```tsx
export function getDiscount(discounted_price: number, original_price: number) {
  return Math.floor((discounted_price / original_price) * 100)
}

```
 - 정가와 할인가를 받아 할인율 계산
 - 할인율 계산 공식 Math.round(((원가 - 할인가) / 원가) * 100)

### 별점 계산 로직 
```tsx
  //별점은 5점 만점 , 아이콘 5개 있어야함
  const filledStarCount = Math.floor(average_rating) // 4.59 -> 4
  const hasHalfStar = average_rating - filledStarCount >= 0.5
  const emptyStar = hasHalfStar ? 5 - 1 - filledStarCount : 5 - filledStarCount
```
- 평점(number)을 받아 별 아이콘 JSX 반환
- FaStar (꽉 찬 별), FaStarHalfAlt (반 별), FaRegStar (빈 별) 조합
- [floor는 소수점을 정수로 변환](https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/Math/floor)
- [리뷰가 0건이라면? 배열의 갯수는 0개](https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/Array/length)


## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1. 리뷰가 없는 경우 UI확인 부탁드립니다. 
