### PR TITLE
feat: 공고 지원 모달 구현 (#66)

### DIFF
--- a/src/components/postings/manage/ApplicantDetailModal.tsx
+++ b/src/components/postings/manage/ApplicantDetailModal.tsx
@@ -1,0 +1,154 @@
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogFooter,
+} from '@/components/common/Modal'
+import { Badge } from '@/components/ui/badge'
+import { getTypeIcon } from '@/helpers/icons'
+import { Button } from '@/components/common'
+import { Skeleton } from '@/components/ui/skeleton'
+import { applicantStatusColor, applicantStatusLabel } from './applicantStatus'
+import type { ApplicantDetail } from './applicantTypes'
+import { cn } from '@/lib/utils'
+
+type ApplicantDetailModalProps = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  applicant: ApplicantDetail | null
+  onApprove?: (id: string) => void
+  onReject?: (id: string) => void
+}
+
+export default function ApplicantDetailModal({
+  open,
+  onOpenChange,
+  applicant,
+  onApprove,
+  onReject,
+}: ApplicantDetailModalProps) {
+  if (!applicant) return null
+
+  const showFooter = applicant.status === 'PENDING'
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="h-[90dvh] max-h-[90dvh] w-[calc(100%-32px)] gap-0 overflow-hidden bg-white p-0 sm:max-h-[1150px] sm:max-w-max md:max-w-2xl"
+        showCloseButton={false}
+      >
+        <div className="flex-between h-[72px] border-b border-gray-200 px-4 py-4 sm:px-6">
+          <h3 className="text-lg font-semibold">지원자 상세정보</h3>
+          <DialogClose asChild>
+            <button className="rounded-full p-2 text-gray-500 transition hover:bg-gray-100 hover:text-gray-700">
+              {getTypeIcon('rejected')}
+            </button>
+          </DialogClose>
+        </div>
+
+        <div
+          className={cn(
+            `flex h-[calc(90dvh-72px-85px)] flex-col gap-4 overflow-y-auto px-4 py-4 sm:h-[calc(90dvh-72px-85px)] sm:px-6`,
+            showFooter
+              ? 'h-[calc(90dvh-72px-85px)] sm:h-[calc(90dvh-72px-85px)]'
+              : 'h-[calc(90dvh-72px)] sm:h-[calc(90dvh-72px)]'
+          )}
+        >
+          <div className="rounded-lg bg-gray-50 p-4">
+            <h4 className="mb-3 text-sm font-semibold text-gray-700">
+              지원자 정보
+            </h4>
+            <div className="flex items-center gap-3">
+              <div className="h-14 w-14 overflow-hidden rounded-full bg-gray-100">
+                {applicant.thumbnail ? (
+                  <img
+                    src={applicant.thumbnail}
+                    alt={applicant.name}
+                    className="h-full w-full object-cover"
+                  />
+                ) : (
+                  <Skeleton className="h-full w-full bg-gray-400" />
+                )}
+              </div>
+              <div className="flex flex-col gap-1">
+                <span className="text-base font-semibold">
+                  {applicant.name}
+                </span>
+                <span className="text-sm text-gray-600">
+                  {applicant.gender}
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <div className="rounded-lg bg-gray-50 p-4">
+            <div className="flex items-start justify-between gap-4">
+              <div className="flex flex-col gap-1 text-sm text-gray-700">
+                <span className="text-gray-500">지원 상태</span>
+                <Badge variant={applicantStatusColor[applicant.status]}>
+                  {applicantStatusLabel[applicant.status]}
+                </Badge>
+              </div>
+              <div className="flex flex-col items-end gap-1 text-sm text-gray-700">
+                <span className="text-gray-500">지원 일시</span>
+                <span>{applicant.appliedAt}</span>
+              </div>
+            </div>
+          </div>
+
+          <Section title="자기소개" content={applicant.selfIntro} />
+          <Section title="지원동기" content={applicant.motivation} />
+          <Section title="스터디 목표" content={applicant.goal} />
+          <Section title="가능한 시간대" content={applicant.availableTime} />
+          <div>
+            <h5 className="mb-2 text-sm font-semibold text-gray-700">
+              스터디 경험
+            </h5>
+            <div className="flex flex-col gap-2 rounded-lg bg-gray-50 p-4">
+              <Badge variant={applicant.hasExperience ? 'success' : 'danger'}>
+                {applicant.hasExperience ? '경험 있음' : '경험 없음'}
+              </Badge>
+              <p className="text-sm whitespace-pre-line text-gray-700">
+                {applicant.experienceDetail}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {showFooter && (
+          <DialogFooter className="h-fit flex-row justify-end gap-3 border-t border-gray-200 p-6">
+            <Button
+              variant="danger"
+              className="w-[84px]"
+              onClick={() => onReject?.(applicant.id)}
+            >
+              {getTypeIcon('rejected')}
+              거절
+            </Button>
+            <Button
+              variant="success"
+              className="w-[84px]"
+              onClick={() => onApprove?.(applicant.id)}
+            >
+              {getTypeIcon('approved')}
+              승인
+            </Button>
+          </DialogFooter>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function Section({ title, content }: { title: string; content: string }) {
+  return (
+    <div>
+      <h5 className="mb-2 text-sm font-semibold text-gray-700">{title}</h5>
+      <div className="rounded-lg bg-gray-50 p-4">
+        <p className="line-clamp-6 text-sm whitespace-pre-line text-gray-700">
+          {content}
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/components/postings/manage/ManageApplicantsModal.tsx
+++ b/src/components/postings/manage/ManageApplicantsModal.tsx
@@ -1,0 +1,111 @@
+import { Dialog, DialogClose, DialogContent } from '@/components/common/Modal'
+import { Badge } from '@/components/ui/badge'
+import { Skeleton } from '@/components/ui/skeleton'
+import { getTypeIcon } from '@/helpers/icons'
+import { Button } from '@/components/common'
+import { applicantStatusColor, applicantStatusLabel } from './applicantStatus'
+import type { Applicant } from './applicantTypes'
+
+type ManageApplicantsModalProps = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  recruitmentTitle: string
+  totalCount: number
+  applicants: Applicant[]
+  onApplicantClick?: (id: string) => void
+}
+
+export default function ManageApplicantsModal({
+  open,
+  onOpenChange,
+  recruitmentTitle,
+  totalCount,
+  applicants,
+  onApplicantClick,
+}: ManageApplicantsModalProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="h-[80dvh] w-[calc(100%-32px)] max-w-4xl gap-0 overflow-hidden p-0 sm:max-w-max md:h-full md:max-h-[593px] md:max-w-4xl"
+        showCloseButton={false}
+      >
+        <div className="flex-between h-[100px] gap-4 border-b border-gray-200 px-4 py-5 sm:px-6">
+          <div className="flex flex-col gap-1">
+            <h3 className="text-lg font-semibold">지원현황관리</h3>
+            <p className="text-sm text-gray-600">
+              {recruitmentTitle} - 총 {totalCount}명이 지원했습니다
+            </p>
+          </div>
+          <DialogClose asChild>
+            {/* <button className="rounded-full p-2 text-gray-500 transition hover:bg-gray-100 hover:text-gray-700">
+              {getTypeIcon('rejected')}
+            </button> */}
+            <Button variant={'ghost'} className="h-10 w-10 rounded-full">
+              {getTypeIcon('rejected')}
+            </Button>
+          </DialogClose>
+        </div>
+        <div className="grid h-[calc(80dvh-100px)] grid-cols-1 gap-3 overflow-y-auto p-4 sm:h-auto sm:p-6 md:grid-cols-2">
+          {applicants.map((applicant) => (
+            <div
+              onClick={() => onApplicantClick?.(applicant.id)}
+              className="flex cursor-pointer gap-3 rounded-lg bg-gray-100 p-4 text-left transition hover:bg-gray-200"
+              key={applicant.id}
+            >
+              <div className="h-12 w-12 shrink-0 overflow-hidden rounded-full">
+                {applicant.thumbnail ? (
+                  <img
+                    src={applicant.thumbnail}
+                    alt={applicant.name}
+                    className="h-full w-full object-cover"
+                  />
+                ) : (
+                  <Skeleton className="h-full w-full bg-gray-400" />
+                )}
+              </div>
+              <div className="flex flex-1 flex-col gap-2">
+                <div className="flex-between gap-2">
+                  <div className="flex flex-col gap-1">
+                    <span className="text-base font-semibold">
+                      {applicant.name}
+                    </span>
+                    <span className="text-sm text-gray-600">
+                      {applicant.gender}
+                    </span>
+                  </div>
+                  <Badge variant={applicantStatusColor[applicant.status]}>
+                    {applicantStatusLabel[applicant.status]}
+                  </Badge>
+                </div>
+                <div className="text-sm text-gray-700">
+                  <div className="mb-3 flex items-center gap-1">
+                    <span className="text-gray-500">지원 일시:</span>
+                    <span>{applicant.appliedAt}</span>
+                  </div>
+                  <div className="mb-3 flex flex-col">
+                    <span className="mb-1 text-[12px] font-medium text-gray-700">
+                      가능한 시간대
+                    </span>
+                    <span className="line-clamp-2">
+                      {applicant.availableTime}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span className="text-[12px] font-medium text-gray-700">
+                      스터디 경험
+                    </span>
+                    <Badge
+                      variant={applicant.hasExperience ? 'success' : 'danger'}
+                    >
+                      {applicant.hasExperience ? '경험 있음' : '경험 없음'}
+                    </Badge>
+                  </div>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/postings/manage/ManageCard.tsx
+++ b/src/components/postings/manage/ManageCard.tsx
@@ -6,6 +6,9 @@ import { Button } from '@/components/common'
 import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
 import type { ManageRecruitment } from '@/types/myRecruitment'
+import ManageApplicantsModal from './ManageApplicantsModal'
+import ApplicantDetailModal from './ApplicantDetailModal'
+import type { Applicant, ApplicantDetail } from './applicantTypes'
 
 type ManageCardProps = {
   posting: ManageRecruitment
@@ -13,6 +16,79 @@ type ManageCardProps = {
 
 export default function ManageCard({ posting }: ManageCardProps) {
   const [imgLoaded, setImgLoaded] = useState(false)
+  const [isModalOpen, setIsModalOpen] = useState(false)
+  const [selectedApplicantId, setSelectedApplicantId] = useState<string | null>(
+    null
+  )
+  // TODO: api 연동 필요
+  const mockApplicants: Applicant[] = [
+    {
+      id: '1',
+      name: '김지원',
+      gender: '여성',
+      status: 'PENDING' as const,
+      appliedAt: '2024-11-25 14:30',
+      availableTime:
+        '평일 저녁 7-10시, 주말 오후 시간대 참여 가능합니다. 평일 저녁 7-10시, 주말 오후 시간대 참여 가능합니다. 평일 저녁 7-10시, 주말 오후 시간대 참여 가능합니다.',
+      hasExperience: false,
+      thumbnail: '',
+    },
+    {
+      id: '2',
+      name: '박개발',
+      gender: '남성',
+      status: 'ACCEPTED' as const,
+      appliedAt: '2024-11-24 10:10',
+      availableTime: '주말 오전/오후, 평일 9시 이후 가능',
+      hasExperience: true,
+      thumbnail: '',
+    },
+    {
+      id: '3',
+      name: '최코딩',
+      gender: '여성',
+      status: 'REJECTED' as const,
+      appliedAt: '2024-11-23 20:45',
+      availableTime: '평일 오후 6-8시',
+      hasExperience: true,
+      thumbnail: '',
+    },
+    {
+      id: '4',
+      name: '이프론트',
+      gender: '남성',
+      status: 'PENDING' as const,
+      appliedAt: '2024-11-22 09:20',
+      availableTime: '주중 8-10시, 주말 오후',
+      hasExperience: false,
+      thumbnail: '',
+    },
+    {
+      id: '5',
+      name: '이프론트',
+      gender: '남성',
+      status: 'CANCELED' as const,
+      appliedAt: '2024-11-22 09:20',
+      availableTime: '주중 8-10시, 주말 오후',
+      hasExperience: false,
+      thumbnail: '',
+    },
+  ]
+
+  const applicantDetails: ApplicantDetail[] = mockApplicants.map(
+    (applicant) => ({
+      ...applicant,
+      selfIntro: '안녕하세요, 백엔드 개발자로 성장하고 싶은 지원자입니다.',
+      motivation:
+        'Node.js 실무 경험을 쌓고 협업 역량을 키우기 위해 지원했습니다.',
+      goal: '스터디를 통해 프로젝트 완성도를 높이고 코드 리뷰를 통해 성장하고 싶습니다.',
+      experienceDetail:
+        '이전에 소규모 스터디에 참여한 경험이 있으며, 주로 서버 API 개발을 맡았습니다.',
+    })
+  )
+
+  const selectedApplicant =
+    applicantDetails.find((a) => a.id === selectedApplicantId) ?? null
 
   return (
     <div className="relative grid gap-4 rounded-lg border border-gray-200 bg-white p-4 md:grid-cols-[160px_1fr] md:items-start">
@@ -95,10 +171,28 @@ export default function ManageCard({ posting }: ManageCardProps) {
 
       {/* 지원 내역 버튼 */}
       <div className="md:absolute md:right-4 md:bottom-4 md:self-end">
-        <Button className="btn-active-blue h-12 w-full px-6 py-3 md:w-[150px]">
+        <Button
+          className="btn-active-blue h-12 w-full px-6 py-3 md:w-[150px]"
+          onClick={() => setIsModalOpen(true)}
+        >
           {getTypeIcon('total')} 지원 내역
         </Button>
       </div>
+      <ManageApplicantsModal
+        open={isModalOpen}
+        onOpenChange={setIsModalOpen}
+        recruitmentTitle={posting.title}
+        totalCount={mockApplicants.length}
+        applicants={mockApplicants}
+        onApplicantClick={(id) => setSelectedApplicantId(id)}
+      />
+      <ApplicantDetailModal
+        open={selectedApplicantId !== null}
+        onOpenChange={(open) =>
+          setSelectedApplicantId(open ? selectedApplicantId : null)
+        }
+        applicant={selectedApplicant}
+      />
     </div>
   )
 }

--- a/src/components/postings/manage/applicantStatus.ts
+++ b/src/components/postings/manage/applicantStatus.ts
@@ -1,0 +1,18 @@
+export type ApplicantStatus = 'PENDING' | 'ACCEPTED' | 'REJECTED' | 'CANCELED'
+
+export const applicantStatusLabel: Record<ApplicantStatus, string> = {
+  PENDING: '대기중',
+  ACCEPTED: '승인됨',
+  REJECTED: '거절됨',
+  CANCELED: '취소됨',
+}
+
+export const applicantStatusColor: Record<
+  ApplicantStatus,
+  'primary' | 'success' | 'danger' | 'discount'
+> = {
+  PENDING: 'primary',
+  ACCEPTED: 'success',
+  REJECTED: 'danger',
+  CANCELED: 'discount',
+}

--- a/src/components/postings/manage/applicantTypes.ts
+++ b/src/components/postings/manage/applicantTypes.ts
@@ -1,0 +1,21 @@
+import type { ApplicantStatus } from './applicantStatus'
+
+// 리스트용 공통 타입
+export type Applicant = {
+  id: string
+  name: string
+  gender: string
+  status: ApplicantStatus
+  appliedAt: string
+  availableTime: string
+  hasExperience: boolean
+  thumbnail?: string
+}
+
+// 상세보기용 확장 타입
+export type ApplicantDetail = Applicant & {
+  selfIntro: string
+  motivation: string
+  goal: string
+  experienceDetail: string
+}


### PR DESCRIPTION


<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #66

## 📑 구현 사항

- 공고 지원자 리스트 모달 UI 구현
- 공고 지원자 상세 정보 모달 UI 구현

## 🌀 어려웠던 점 / 고민했던 부분

- 비슷한 구조의 데이터를 props로 내리면서 처리할때 쓰는 타입들이나 ui 구조를 어떻게 재사용성을 높일까에 대해 좀더 고민해봤던거같습니다.


## 📸 구현 이미지

- 

Uploading 화면 기록 2025-12-12 오전 3.48.02.mov…


https://github.com/user-attachments/assets/f0c39762-10d1-45ec-9c21-27b78487e20d



## ❇️ 코드 설명

- ManageCard 컴포넌트에서 해당 공고 지원 내역 정보를 조회하여 props로 전달합니다. ( 현재 목데이터 임시구현, msw 연동예정)
```tsx

// 모달 관련 변수 및 상세 조회 id 저장 변수
const [isModalOpen, setIsModalOpen] = useState(false)
const [selectedApplicantId, setSelectedApplicantId] = useState<string | null>
  
  ...
  
<ManageApplicantsModal
   open={isModalOpen}
   onOpenChange={setIsModalOpen}
   recruitmentTitle={posting.title}
   totalCount={mockApplicants.length}
   applicants={mockApplicants}
   onApplicantClick={(id) => setSelectedApplicantId(id)}
/>
<ApplicantDetailModal
   open={selectedApplicantId !== null}
   onOpenChange={(open) =>
     setSelectedApplicantId(open ? selectedApplicantId : null)
   }
   applicant={selectedApplicant}
/>
```

각 모달에선 공통 컴포넌트인 Dialog를 활용하여 구현하였습니다.

## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1. 지원자 리스트 모달과 상세 모달 디자인 적인 부분에서도 css 관련하여 스크롤 영역을 잡아주다 보니 강제로 본문 영역의 height값을 지정해야해 가독성이 좋지 않은 스타일링이 되는것도 같아서 이부분에 대해서 의견 주시면 좋을거같습니다.
