### PR TITLE
refactor: 멘토링 피드백 반영하여 이미지 처리 및 로그인 확인 훅 위치 이동(#89)

### DIFF
--- a/.github/workflows/deploy-to-yeeun-repo.yml
+++ b/.github/workflows/deploy-to-yeeun-repo.yml
@@ -1,0 +1,30 @@
+name: Sync to yeeun repo
+
+on:
+  push:
+    branches: ["develop"] # 조직 레포 devleop 에 push될 때 트리거
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install mustache (to update the date)
+        run: sudo apt-get update && sudo apt-get install -y ruby && sudo gem install mustache
+
+      - name: Create output directory with full repo content
+        run: bash ./build.sh
+
+      - name: Pushes to another repository
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.AUTO_ACTIONS }}
+        with:
+          source-directory: "output"
+          destination-github-username: "yeeun-kor"
+          destination-repository-name: "oz-externship-fe-04-team3"
+          user-email: ${{ secrets.EMAIL }}
+          commit-message: ${{ github.event.commits[0].message }}
+          target-branch: develop

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-separator": "^1.1.8",
         "@radix-ui/react-slot": "^1.2.4",
+        "@radix-ui/react-visually-hidden": "^1.2.4",
         "@tanstack/react-query": "^5.80.7",
         "axios": "^1.10.0",
         "framer-motion": "^12.23.24",
@@ -2119,6 +2120,29 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
+      "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-separator": {
       "version": "1.1.8",
       "resolved": "https://registry.npmmirror.com/@radix-ui/react-separator/-/react-separator-1.1.8.tgz",
@@ -2320,12 +2344,35 @@
       }
     },
     "node_modules/@radix-ui/react-visually-hidden": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmmirror.com/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
-      "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.4.tgz",
+      "integrity": "sha512-kaeiyGCe844dkb9AVF+rb4yTyb1LiLN/e3es3nLiRyN4dC8AduBYPMnnNlDjX2VDOcvDEiPnRNMJeWCfsX0txg==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-primitive": "2.1.3"
+        "@radix-ui/react-primitive": "2.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz",
+      "integrity": "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.4"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-visually-hidden": "^1.2.4",
     "@tanstack/react-query": "^5.80.7",
     "axios": "^1.10.0",
     "framer-motion": "^12.23.24",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,33 @@
 import AppRoutes from '@/routes/AppRoutes'
+import { useEffect } from 'react'
 import { ToastContainer } from 'react-toastify'
-import { useAuth } from './hooks/useAuth'
+import { getUserInformationApi } from './api/userInformation'
+import { useAuthStore } from './store/userStore'
 
 function App() {
+  useEffect(() => {
+    const initAuth = async () => {
+      try {
+        if (import.meta.env.VITE_NODE_ENV === 'development') {
+          const userData = await getUserInformationApi()
+          useAuthStore.getState().setUser(userData)
+        } else {
+          try {
+            const userData = await getUserInformationApi()
+            useAuthStore.getState().setUser(userData)
+          } catch (error) {
+            console.log(error, '토큰발급에러')
+            return
+          }
+        }
+      } catch (error) {
+        console.log(error, '비회원입니다')
+      }
+    }
+    initAuth()
+  }, [])
   return (
     <>
-      {/* 토큰으로 회원,비회원 확인 */}
-      {useAuth()}
       <AppRoutes />
       <ToastContainer
         position="top-right"

--- a/src/api/lecture.ts
+++ b/src/api/lecture.ts
@@ -25,12 +25,12 @@ export async function getLecturesApi(
 }
 /* 북마크 */
 export async function getBookmark(): Promise<BookmarkResponse> {
-  const { data } = await axiosInstance.get(`v1/lecture-bookmarks`)
+  const { data } = await axiosInstance.get(`/v1/lecture-bookmarks`)
   return data
 }
 
 export async function addBookmark(lectureId: number): Promise<string> {
-  const { data } = await axiosInstance.post('v1/lecture-bookmarks', {
+  const { data } = await axiosInstance.post('/v1/lecture-bookmarks', {
     lecture_id: lectureId,
   })
   return data.detail
@@ -38,7 +38,7 @@ export async function addBookmark(lectureId: number): Promise<string> {
 
 export async function deleteBookmark(lectureId: number): Promise<string> {
   const { data } = await axiosInstance.delete(
-    `v1/lecture-bookmarks/${lectureId}`
+    `/v1/lecture-bookmarks/${lectureId}`
   )
   return data.detail
 }

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -199,7 +199,7 @@ function DialogContent({
           data-slot="dialog-content"
           className={cn(
             'bg-background fixed top-[50%] left-[50%] z-50',
-            'flex max-h-[80dvh] w-full max-w-sm sm:max-w-lg',
+            'flex max-h-[80dvh] w-sm sm:max-w-lg',
             'translate-x-[-50%] translate-y-[-50%]',
             'flex-col overflow-hidden rounded-lg border shadow-lg',
             className

--- a/src/components/common/accordion.tsx
+++ b/src/components/common/accordion.tsx
@@ -33,7 +33,7 @@ function AccordionTrigger({
       <AccordionPrimitive.Trigger
         data-slot="accordion-trigger"
         className={cn(
-          'focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180',
+          'focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-start gap-4 rounded-md py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180',
           className
         )}
         {...props}

--- a/src/components/common/card.tsx
+++ b/src/components/common/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<'div'>) {
     <div
       data-slot="card"
       className={cn(
-        'bg-card text-card-foreground relative flex flex-col overflow-hidden rounded-lg border shadow-sm',
+        'bg-card text-card-foreground relative flex flex-col overflow-hidden rounded-lg shadow-sm',
         className
       )}
       {...props}
@@ -65,7 +65,7 @@ function CardContent({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="card-content"
-      className={cn('flex flex-col items-start gap-4 p-4', className)}
+      className={cn('flex flex-1 flex-col items-start gap-4 p-4', className)}
       {...props}
     />
   )

--- a/src/components/lecture/LectureCard.tsx
+++ b/src/components/lecture/LectureCard.tsx
@@ -46,8 +46,9 @@ export default function LectureCard(lecture: Lecture) {
     reviews,
   } = lecture
 
-  /* 리뷰보기 모달창 상태 */
+  /* 리뷰보기 모달창 및 이미지 로드  상태 */
   const [showReviewModal, setReviewShowModal] = useState(false)
+  const [imgLoaded, setImgLoaded] = useState(false)
   /* 로그인 분기 처리 */
   const { loginState } = useAuthStore()
   /* 북마크 커스텀 상태 */
@@ -79,8 +80,8 @@ export default function LectureCard(lecture: Lecture) {
   return (
     <Card className="w-full">
       <CardHeader>
-        <CardAction className="absolute z-2 justify-between px-3 py-3">
-          <div className="top-2 flex flex-col gap-2">
+        <CardAction className="absolute justify-between px-3 py-3">
+          <div className="absolute top-2 flex flex-col gap-2">
             <Badge variant={'platform'}>{platform}</Badge>
             <Badge variant={'discount'}>
               {getDiscount(discounted_price, original_price)}% 할인
@@ -89,7 +90,7 @@ export default function LectureCard(lecture: Lecture) {
           <Button
             variant="outline"
             size={'icon'}
-            className="rounded-full border-none"
+            className="absolute right-2 rounded-full border-none"
             aria-label="강의 북마크하기"
             onClick={handleBookmarkClick}
           >
@@ -100,15 +101,15 @@ export default function LectureCard(lecture: Lecture) {
             />
           </Button>
         </CardAction>
-        {thumbnail_img_url ? (
-          <img
-            src={thumbnail_img_url}
-            alt={title}
-            className="h-auto w-full object-cover"
-          />
-        ) : (
-          <Skeleton></Skeleton>
-        )}
+        {/* IMG 로딩중이면 스켈레톤  */}
+        {!imgLoaded && <Skeleton className="h-[210px] w-[390px]" />}
+        <img
+          src={thumbnail_img_url}
+          alt={title}
+          onLoad={() => setImgLoaded(true)}
+          onError={() => setImgLoaded(true)}
+          className="h-auto w-full object-cover"
+        />
       </CardHeader>
       <CardContent>
         <div className="Card-Content-badge flex gap-1">
@@ -152,7 +153,7 @@ export default function LectureCard(lecture: Lecture) {
         )}
         {/* 모바일 버전 */}
         {!isDesktop && (
-          <Accordion type="single" collapsible>
+          <Accordion type="single" collapsible className="w-full">
             <AccordionItem value="item-1">
               <AccordionTrigger
                 className="text-primary-500"
@@ -162,7 +163,7 @@ export default function LectureCard(lecture: Lecture) {
               </AccordionTrigger>
               <AccordionContent className="flex flex-col gap-2">
                 {reviews.length === 0 ? (
-                  <Item className="w-full">
+                  <Item>
                     <ItemContent>
                       <ItemTitle>{getRatingStarsIcon(0)}</ItemTitle>
                       <ItemDescription>리뷰가 없습니다</ItemDescription>
@@ -170,7 +171,7 @@ export default function LectureCard(lecture: Lecture) {
                   </Item>
                 ) : (
                   reviews.map((i) => (
-                    <Item key={i.id} className="w-full">
+                    <Item key={i.id}>
                       <ItemContent>
                         <ItemTitle>{getRatingStarsIcon(i.rating)}</ItemTitle>
                         <ItemDescription>{i.content}</ItemDescription>
@@ -183,7 +184,7 @@ export default function LectureCard(lecture: Lecture) {
           </Accordion>
         )}
         <Button
-          className="absolute top-6 right-2"
+          className="absolute top-6 right-2 shrink-0"
           aria-label={`${title} 강의 페이지로 이동`}
           onClick={() => {
             window.open(url_link, '_blank')

--- a/src/components/lecture/LectureCard.tsx
+++ b/src/components/lecture/LectureCard.tsx
@@ -78,7 +78,7 @@ export default function LectureCard(lecture: Lecture) {
     }
   }, [isDesktop])
   return (
-    <Card className="w-full">
+    <Card>
       <CardHeader>
         <CardAction className="absolute justify-between px-3 py-3">
           <div className="absolute top-2 flex flex-col gap-2">
@@ -102,13 +102,13 @@ export default function LectureCard(lecture: Lecture) {
           </Button>
         </CardAction>
         {/* IMG 로딩중이면 스켈레톤  */}
-        {!imgLoaded && <Skeleton className="h-[210px] w-[390px]" />}
+        {!imgLoaded && <Skeleton className="h-[210px] w-full" />}
         <img
           src={thumbnail_img_url}
           alt={title}
           onLoad={() => setImgLoaded(true)}
           onError={() => setImgLoaded(true)}
-          className="h-auto w-full object-cover"
+          className="aspect-auto max-h-[210px] w-full object-cover"
         />
       </CardHeader>
       <CardContent>

--- a/src/components/lecture/LectureCard.tsx
+++ b/src/components/lecture/LectureCard.tsx
@@ -105,7 +105,6 @@ export default function LectureCard(lecture: Lecture) {
             src={thumbnail_img_url}
             alt={title}
             className="h-auto w-full object-cover"
-            loading="lazy"
           />
         ) : (
           <Skeleton></Skeleton>

--- a/src/components/lecture/LectureReviewCard.tsx
+++ b/src/components/lecture/LectureReviewCard.tsx
@@ -2,7 +2,14 @@ import { getDiscount } from '@/helpers/getDiscount'
 import getRatingStarsIcon from '@/helpers/getRatingStarsIcon'
 import { LectureLevel } from '@/mappers/lectures/lecture'
 import type { Lecture } from '@/types/lecture'
-import { Dialog, DialogContent } from '../common/Modal'
+import { VisuallyHidden } from '@radix-ui/react-visually-hidden'
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from '../common/Modal'
 import { Badge } from '../common/badge'
 import {
   Card,
@@ -42,6 +49,12 @@ export default function LectureReviewCard({
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogContent className="m-0 p-0 **:data-[slot='dialog-close']:bg-gray-300">
+        <VisuallyHidden asChild>
+          <DialogTitle></DialogTitle>
+        </VisuallyHidden>
+        <VisuallyHidden asChild>
+          <DialogDescription></DialogDescription>
+        </VisuallyHidden>
         <Card className="w-full">
           <CardHeader>
             <CardAction className="absolute z-10 justify-between px-3 py-3">

--- a/src/components/lecture/LectureReviewCard.tsx
+++ b/src/components/lecture/LectureReviewCard.tsx
@@ -59,7 +59,7 @@ export default function LectureReviewCard({
         <VisuallyHidden asChild>
           <DialogDescription></DialogDescription>
         </VisuallyHidden>
-        <Card className="w-full">
+        <Card>
           <CardHeader>
             <CardAction className="absolute z-10 justify-between px-3 py-3">
               <div className="top-2 flex flex-col gap-2">
@@ -78,7 +78,7 @@ export default function LectureReviewCard({
               alt={title}
               onLoad={() => setImgLoaded(true)}
               onError={() => setImgLoaded(true)}
-              className="h-auto w-full object-cover"
+              className="aspect-auto max-h-[210px] w-full object-cover"
             />
           </CardHeader>
           <div className="review-content-section overflow-y-auto">

--- a/src/components/lecture/LectureReviewCard.tsx
+++ b/src/components/lecture/LectureReviewCard.tsx
@@ -57,10 +57,9 @@ export default function LectureReviewCard({
                 src={thumbnail_img_url}
                 alt={title}
                 className="h-auto w-full object-cover"
-                loading="lazy"
               />
             ) : (
-              <Skeleton></Skeleton>
+              <Skeleton className="h-24 w-24"></Skeleton>
             )}
           </CardHeader>
           <div className="review-content-section overflow-y-auto">

--- a/src/components/lecture/LectureReviewCard.tsx
+++ b/src/components/lecture/LectureReviewCard.tsx
@@ -4,6 +4,7 @@ import { LectureLevel } from '@/mappers/lectures/lecture'
 import type { Lecture } from '@/types/lecture'
 import { VisuallyHidden } from '@radix-ui/react-visually-hidden'
 
+import { useState } from 'react'
 import {
   Dialog,
   DialogContent,
@@ -46,6 +47,9 @@ export default function LectureReviewCard({
     categories,
     reviews,
   } = lecture
+
+  const [imgLoaded, setImgLoaded] = useState(false)
+
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogContent className="m-0 p-0 **:data-[slot='dialog-close']:bg-gray-300">
@@ -65,15 +69,17 @@ export default function LectureReviewCard({
                 </Badge>
               </div>
             </CardAction>
-            {thumbnail_img_url ? (
-              <img
-                src={thumbnail_img_url}
-                alt={title}
-                className="h-auto w-full object-cover"
-              />
-            ) : (
-              <Skeleton className="h-24 w-24"></Skeleton>
+            {/* IMG 로딩중이면 스켈레톤  */}
+            {!imgLoaded && (
+              <Skeleton className="h-auto min-h-[210px] min-w-[390px]" />
             )}
+            <img
+              src={thumbnail_img_url}
+              alt={title}
+              onLoad={() => setImgLoaded(true)}
+              onError={() => setImgLoaded(true)}
+              className="h-auto w-full object-cover"
+            />
           </CardHeader>
           <div className="review-content-section overflow-y-auto">
             <CardContent>

--- a/src/components/postings/manage/ManageCard.tsx
+++ b/src/components/postings/manage/ManageCard.tsx
@@ -6,9 +6,9 @@ import { Badge } from '@/components/common/badge'
 import { Skeleton } from '@/components/common/skeleton'
 import { getTypeIcon } from '@/helpers/icons'
 import type { ManageRecruitment } from '@/types/myRecruitment'
-import ManageApplicantsModal from './ManageApplicantsModal'
 import ApplicantDetailModal from './ApplicantDetailModal'
 import type { Applicant, ApplicantDetail } from './applicantTypes'
+import ManageApplicantsModal from './ManageApplicantsModal'
 
 type ManageCardProps = {
   posting: ManageRecruitment
@@ -100,7 +100,6 @@ export default function ManageCard({ posting }: ManageCardProps) {
         <img
           src={posting.thumbnailImgUrl}
           alt={posting.title}
-          loading="lazy"
           onLoad={() => setImgLoaded(true)}
           onError={() => setImgLoaded(true)}
           className={`mx-auto h-32 w-full rounded-md object-cover transition-opacity duration-200 md:h-24 md:w-40 ${

--- a/src/pages/CoursesPage.tsx
+++ b/src/pages/CoursesPage.tsx
@@ -9,7 +9,7 @@ import { categoryData, sortData } from '@/mappers/lectures/lecture'
 import { useAuthStore } from '@/store/userStore'
 import type { LecturesParams } from '@/types/lecture'
 import { ArrowDownWideNarrow, Folder, Search } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { useInView } from 'react-intersection-observer'
 
 export default function Courses() {
@@ -33,17 +33,22 @@ export default function Courses() {
         }),
     })
   //무한스크롤
-  const { ref, inView } = useInView({
+  const { ref } = useInView({
     threshold: 0,
     rootMargin: '50px',
+    onChange(inView) {
+      if (inView && hasNextPage && !isFetchingNextPage) {
+        fetchNextPage()
+      }
+    },
   })
 
   //inView 변할 때 마다, 다음페이지 호출
-  useEffect(() => {
-    if (inView && hasNextPage && !isFetchingNextPage) {
-      fetchNextPage()
-    }
-  }, [inView, hasNextPage, isFetchingNextPage, fetchNextPage])
+  // useEffect(() => {
+  //   if (inView && hasNextPage && !isFetchingNextPage) {
+  //     fetchNextPage()
+  //   }
+  // }, [inView, hasNextPage, isFetchingNextPage, fetchNextPage])
 
   /* 유저 상태 */
   const { loginState } = useAuthStore()
@@ -112,12 +117,7 @@ export default function Courses() {
           더 이상 강의가 없습니다.
         </div>
       ) : (
-        <div
-          className="bg-primary-500 flex-center mt-12 h-12 rounded-md text-center text-white"
-          ref={ref}
-        >
-          더많은 강의 보기
-        </div>
+        <div ref={ref}></div>
       )}
     </div>
   )


### PR DESCRIPTION
<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#89)
-->

## #️⃣ 연관된 이슈

- Resolves #89
- Resolves #80


## 📑 구현 사항
### 1. 이미지 로딩 최적화

- `loading="lazy"` 속성 제거하고 이미지 로드 상태 관리로 전환
- `onLoad`/`onError` 이벤트를 활용한 스켈레톤 UI 표시 개선
- 참고자료 : 지훈님코드

### 2. 무한 스크롤 성능 개선

- useEffect 기반 페이지 호출을 `useInView`의 `onChange` 콜백으로 변경
- 불필요한 리렌더링 방지 및 API 호출 최적화
- 참고자료 : `onChange` 콜백  https://www.npmjs.com/package/react-intersection-observer

### 3. 사용자 인증 로직 개선

- 멘토님의 조언 반영하여, 유저 정보 호출을 App.tsx에서 중앙화하여 초기화
- 재사용하지 않는 useAuth 훅 제거 및 로직 단순화

### 4. UI 컴포넌트 개선

- Card 컴포넌트에서 불필요한 border 제거
- 카드 컨텐츠의 flex-1 추가로 레이아웃 개선


## 🌀 어려웠던 점 / 고민했던 부분
### 접근성 개선 (Dialog 컴포넌트)
<img width="2436" height="1212" alt="image" src="https://github.com/user-attachments/assets/a8691059-1444-406b-832d-169851853e45" />

- 모달창 오픈하니 위와 같은 경고 메시지가 콘솔창에 나왔다. 
>  #### Radix UI의 DialogContent 컴포넌트는 스크린 리더(Screen Reader) 사용자를 위해 반드시 DialogTitle이 필요합니다. 
- 즉, 스크린 리더는 시각 장애인들이 웹 페이지를 읽을 수 있도록 도와주는 보조 기술인데, 
-  Radix UI 컴포넌트 사용하려면 필수라는 것
- 그러나 나는 따로 Modal내부에서 Card컴포넌트를 사용하고 싶었기 때문에, DialogTitle 숨겨주어야 했다. 

<img width="858" height="392" alt="image" src="https://github.com/user-attachments/assets/4f0eb2c0-b186-4993-900e-189af77cb05d" />

### 해결완료 
<img width="1014" height="346" alt="image" src="https://github.com/user-attachments/assets/a79c09c8-99f5-4eae-a1cc-1a353566a3eb" />

<img width="2600" height="1338" alt="image" src="https://github.com/user-attachments/assets/ed3b05a5-007c-467e-9c20-7ed4e136bc52" />

- 그래서 내린 결론은 필수요소를 추가하고, 공식문서에서 제안한 VisuallyHidden 활용한 스크린 리더 대응하였다.
- 패키지: `@radix-ui/react-visually-hidden` 추가
- 참고자료: https://www.radix-ui.com/primitives/docs/components/dialog#title

## 📸 구현 이미지
### 이미지 로딩 최적화 
#### 모달창
![모달창이미지최적화](https://github.com/user-attachments/assets/15de1a49-657c-4397-9a3e-3b12808d4a84)


#### 카드영역
![카드이미지최적화](https://github.com/user-attachments/assets/ad2a3661-bbe3-44b9-bbdd-aa506cbe0925)


### 카드 컨텐츠의 타이틀 영역을 flex-1
#### 비포
<img width="1204" height="978" alt="image" src="https://github.com/user-attachments/assets/20b314af-62b9-487f-b451-0a00435fa6c8" /> 
 
- 카드 타이틀 영역이 2줄로 떨어지면서, 카드의 푸터가 붕 뜬 상황 

#### 애프터
<img width="612" height="496" alt="스크린샷 2025-12-18 오후 2 14 17" src="https://github.com/user-attachments/assets/f64d7550-5fe5-4531-bd40-9c9104b61a12" />

- 카드 컨텐츠의 flex-1  를 줌으로써 이를 해결함

## ❇️ 코드 설명
### 스크롤 성능 개선 
<img width="740" height="538" alt="image" src="https://github.com/user-attachments/assets/5a0e55ac-8e14-4b71-a483-ef562d29a80d" />

- 페이지 호출이 한번에 2개씩 호출되고 있는 상황 

```tsx
  //무한스크롤
  const { ref } = useInView({
    threshold: 0,
    rootMargin: '50px',
    onChange(inView) {
      if (inView && hasNextPage && !isFetchingNextPage) {
        fetchNextPage()
      }
    },
  })

  //inView 변할 때 마다, 다음페이지 호출
  // useEffect(() => {
  //   if (inView && hasNextPage && !isFetchingNextPage) {
  //     fetchNextPage()
  //   }
  // }, [inView, hasNextPage, isFetchingNextPage, fetchNextPage])
```


<img width="764" height="351" alt="image" src="https://github.com/user-attachments/assets/7132feda-151f-4f93-b8a8-c6f377686b3c" />

- 멘토님의 조언대로 `useEffect` 대신, `onChange`를 활용하여 이를 해결하였다. 
- 이유는 트러블슈팅을 통해서 , 블로그 정리해서 공유 드리겠습니다. 


### 사용자 훅 위치 변경 
```tsx
function App() {
  useEffect(() => {
    const initAuth = async () => {
      try {
        if (import.meta.env.VITE_NODE_ENV === 'development') {
          const userData = await getUserInformationApi()
          useAuthStore.getState().setUser(userData)
        } else {
          try {
            const userData = await getUserInformationApi()
            useAuthStore.getState().setUser(userData)
          } catch (error) {
            console.log(error, '토큰발급에러')
            return
          }
        }
      } catch (error) {
        console.log(error, '비회원입니다')
      }
    }
    initAuth()
  }, [])
  return (
    <>
      <AppRoutes />
      <ToastContainer
        position="top-right"
        autoClose={3000}
        icon={false}
        closeButton={false}
      />
    </>
  )
}
```
- 위치 변경 하였습니다. 
## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1. 카드 이미지 스켈레톤으로 대체할때, 높이를 `h-auto`로 맞추었는데, 이게 바람직한 사이즈일까요? 실제로 어떤 이미지파일이 들어올지 모르겠는데,,, 조언을 듣고싶습니다. 
