### PR TITLE
build: 예은repo자동화 액션 (#88)

### DIFF
--- a/.github/workflows/deploy-yeeun-repo-cicd.yml
+++ b/.github/workflows/deploy-yeeun-repo-cicd.yml
@@ -1,0 +1,30 @@
+name: Sync to yeeun repo
+
+on:
+  push:
+    branches: ["develop"] # 조직 레포 devleop 에 push될 때 트리거
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install mustache (to update the date)
+        run: sudo apt-get update && sudo apt-get install -y ruby && sudo gem install mustache
+
+      - name: Create output directory with full repo content
+        run: bash ./build.sh
+
+      - name: Pushes to another repository
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.AUTO_ACTIONS }}
+        with:
+          source-directory: "output"
+          destination-github-username: "yeeun-kor"
+          destination-repository-name: "oz-externship-fe-04-team3"  # 목적지 레포 이름
+          user-email: ${{ secrets.EMAIL }}
+          commit-message: ${{ github.event.commits[0].message }}
+          target-branch: develop


### PR DESCRIPTION
- 깃허브 액션 설정
- 조직repo의 develop 푸쉬가 되면
- 예은 repo로 자동 동기화 실행

<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #88

## 📑 구현 사항

- cicd 워크플로우 작성함.

## 🌀 어려웠던 점 / 고민했던 부분

-

## 📸 구현 이미지
### 깃허브 액션 설정
- 필요한 환경변수인 깃허브토큰( 예은토큰) 과 이메일(예은이메일) 설정하였습니다 
<img width="1023" height="344" alt="스크린샷 2025-12-18 오후 3 31 20" src="https://github.com/user-attachments/assets/08e5aa41-c592-449f-8b4a-bed1a892f0ab" />


## ❇️ 코드 설명
```yml
     - name: Pushes to another repository
        uses: cpina/github-action-push-to-another-repository@main
        env:
          API_TOKEN_GITHUB: ${{ secrets.AUTO_ACTIONS }}
        with:
          source-directory: "output"
          destination-github-username: "yeeun-kor"
          destination-repository-name: "oz-externship-fe-04-team3"  # 목적지 레포 이름
          user-email: ${{ secrets.EMAIL }}
          commit-message: ${{ github.event.commits[0].message }}
          target-branch: develop
```

- 현재 develop 브랜치가 push되면 
- 저의 개인 repo의 develop 로 동기화 시키는 로직 입니다.

## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1.
