### PR TITLE
feat: 알림 스트림 훅 추가 및 연결 (#102)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@radix-ui/react-visually-hidden": "^1.2.4",
         "@tanstack/react-query": "^5.80.7",
         "axios": "^1.10.0",
+        "event-source-polyfill": "^1.0.31",
         "framer-motion": "^12.23.24",
         "lucide-react": "^0.515.0",
         "motion": "^12.23.26",
@@ -5084,6 +5085,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/event-source-polyfill": {
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-1.0.31.tgz",
+      "integrity": "sha512-4IJSItgS/41IxN5UVAVuAyczwZF7ZIEsM1XAoUzIHA6A+xzusEZUutdXz2Nr+MQPLxfTiCvqE79/C8HT8fKFvA==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@radix-ui/react-visually-hidden": "^1.2.4",
     "@tanstack/react-query": "^5.80.7",
     "axios": "^1.10.0",
+    "event-source-polyfill": "^1.0.31",
     "framer-motion": "^12.23.24",
     "lucide-react": "^0.515.0",
     "motion": "^12.23.26",

--- a/src/components/common/notification/NotificationModal.tsx
+++ b/src/components/common/notification/NotificationModal.tsx
@@ -5,6 +5,7 @@ import {
   useNotificationActions,
   useNotifications,
 } from '@/hooks/quries/useNotifications'
+import { useNotificationStream } from '@/hooks/useNotificationStream'
 import type { AlarmItem } from '@/types/alarm'
 
 import NotificationCard from './NotificationCard'
@@ -39,6 +40,12 @@ export default function NotificationModal({
   const unreadCount = alarms.filter((a) => !a.isRead).length
   const readCount = totalCount - unreadCount
   const controls = useAnimation()
+
+  useNotificationStream({
+    onMessage: () => {
+      refetch()
+    },
+  })
 
   // 진입 위치 초기화
   useEffect(() => {

--- a/src/components/common/notification/NotificationModal.tsx
+++ b/src/components/common/notification/NotificationModal.tsx
@@ -42,10 +42,8 @@ export default function NotificationModal({
   const unreadCount = alarms.filter((a) => !a.isRead).length
   const readCount = totalCount - unreadCount
   const controls = useAnimation()
-  const { setAccessToken, clearAuth } = useAuthStore((s) => ({
-    setAccessToken: s.setAccessToken,
-    clearAuth: s.clearAuth,
-  }))
+  const setAccessToken = useAuthStore((s) => s.setAccessToken)
+  const clearAuth = useAuthStore((s) => s.clearAuth)
 
   useNotificationStream({
     onMessage: () => {

--- a/src/components/common/notification/NotificationModal.tsx
+++ b/src/components/common/notification/NotificationModal.tsx
@@ -5,8 +5,10 @@ import {
   useNotificationActions,
   useNotifications,
 } from '@/hooks/quries/useNotifications'
+import { getAccessTokenApi } from '@/api/userInformation'
 import { useNotificationStream } from '@/hooks/useNotificationStream'
 import type { AlarmItem } from '@/types/alarm'
+import { useAuthStore } from '@/store/userStore'
 
 import NotificationCard from './NotificationCard'
 
@@ -40,10 +42,22 @@ export default function NotificationModal({
   const unreadCount = alarms.filter((a) => !a.isRead).length
   const readCount = totalCount - unreadCount
   const controls = useAnimation()
+  const { setAccessToken, clearAuth } = useAuthStore((s) => ({
+    setAccessToken: s.setAccessToken,
+    clearAuth: s.clearAuth,
+  }))
 
   useNotificationStream({
     onMessage: () => {
       refetch()
+    },
+    onUnauthorized: async () => {
+      try {
+        const newToken = await getAccessTokenApi()
+        setAccessToken(newToken)
+      } catch (err) {
+        clearAuth()
+      }
     },
   })
 

--- a/src/hooks/useNotificationStream.ts
+++ b/src/hooks/useNotificationStream.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { EventSourcePolyfill } from 'event-source-polyfill'
 import { API_BASE_URL } from '@/constant/api'
@@ -16,6 +16,12 @@ type UseNotificationStreamOptions = {
 export function useNotificationStream(options?: UseNotificationStreamOptions) {
   const queryClient = useQueryClient()
   const accessToken = useAuthStore((s) => s.accessToken)
+  const optionsRef = useRef(options)
+  const handledUnauthorizedRef = useRef(false)
+
+  useEffect(() => {
+    optionsRef.current = options
+  }, [options])
 
   useEffect(() => {
     if (!accessToken) return
@@ -33,7 +39,7 @@ export function useNotificationStream(options?: UseNotificationStreamOptions) {
         const raw = JSON.parse(event.data) as NotificationApiItem
         const alarm = alarmMapper(raw)
         queryClient.invalidateQueries({ queryKey: ['notifications'] })
-        options?.onMessage?.(alarm)
+        optionsRef.current?.onMessage?.(alarm)
       } catch (e) {
         // eslint-disable-next-line no-console
         console.error('SSE parse error', e)
@@ -43,12 +49,15 @@ export function useNotificationStream(options?: UseNotificationStreamOptions) {
     type SSEErrorEvent = Event & { status?: number }
 
     es.onerror = (event: SSEErrorEvent) => {
-      if (event.status === 401) options?.onUnauthorized?.()
+      if (event.status === 401 && !handledUnauthorizedRef.current) {
+        handledUnauthorizedRef.current = true
+        optionsRef.current?.onUnauthorized?.()
+      }
       es.close()
     }
 
     return () => {
       es.close()
     }
-  }, [accessToken, options, queryClient])
+  }, [accessToken, queryClient])
 }

--- a/src/hooks/useNotificationStream.ts
+++ b/src/hooks/useNotificationStream.ts
@@ -1,27 +1,37 @@
 import { useEffect } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
+import { EventSourcePolyfill } from 'event-source-polyfill'
 import { API_BASE_URL } from '@/constant/api'
 import {
   alarmMapper,
   type NotificationApiItem,
 } from '@/mappers/notification/mapper'
+import { useAuthStore } from '@/store/userStore'
 
 type UseNotificationStreamOptions = {
   onMessage?: (data: ReturnType<typeof alarmMapper>) => void
+  onUnauthorized?: () => void
 }
 
 export function useNotificationStream(options?: UseNotificationStreamOptions) {
   const queryClient = useQueryClient()
+  const accessToken = useAuthStore((s) => s.accessToken)
 
   useEffect(() => {
-    const streamUrl = `${API_BASE_URL}/v1/notifications/stream`
-    const es = new EventSource(streamUrl, { withCredentials: true })
+    if (!accessToken) return
 
-    es.onmessage = (event) => {
+    const streamUrl = `${API_BASE_URL}/v1/notifications/stream`
+    const es = new EventSourcePolyfill(streamUrl, {
+      withCredentials: true,
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    })
+
+    es.onmessage = (event: MessageEvent) => {
       try {
         const raw = JSON.parse(event.data) as NotificationApiItem
         const alarm = alarmMapper(raw)
-        // 새 알림이 올 때 무한스크롤 쿼리 갱신
         queryClient.invalidateQueries({ queryKey: ['notifications'] })
         options?.onMessage?.(alarm)
       } catch (e) {
@@ -30,12 +40,15 @@ export function useNotificationStream(options?: UseNotificationStreamOptions) {
       }
     }
 
-    es.onerror = () => {
+    type SSEErrorEvent = Event & { status?: number }
+
+    es.onerror = (event: SSEErrorEvent) => {
+      if (event.status === 401) options?.onUnauthorized?.()
       es.close()
     }
 
     return () => {
       es.close()
     }
-  }, [options, queryClient])
+  }, [accessToken, options, queryClient])
 }

--- a/src/hooks/useNotificationStream.ts
+++ b/src/hooks/useNotificationStream.ts
@@ -1,0 +1,41 @@
+import { useEffect } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { API_BASE_URL } from '@/constant/api'
+import {
+  alarmMapper,
+  type NotificationApiItem,
+} from '@/mappers/notification/mapper'
+
+type UseNotificationStreamOptions = {
+  onMessage?: (data: ReturnType<typeof alarmMapper>) => void
+}
+
+export function useNotificationStream(options?: UseNotificationStreamOptions) {
+  const queryClient = useQueryClient()
+
+  useEffect(() => {
+    const streamUrl = `${API_BASE_URL}/v1/notifications/stream`
+    const es = new EventSource(streamUrl, { withCredentials: true })
+
+    es.onmessage = (event) => {
+      try {
+        const raw = JSON.parse(event.data) as NotificationApiItem
+        const alarm = alarmMapper(raw)
+        // 새 알림이 올 때 무한스크롤 쿼리 갱신
+        queryClient.invalidateQueries({ queryKey: ['notifications'] })
+        options?.onMessage?.(alarm)
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error('SSE parse error', e)
+      }
+    }
+
+    es.onerror = () => {
+      es.close()
+    }
+
+    return () => {
+      es.close()
+    }
+  }, [options, queryClient])
+}

--- a/src/types/event-source-polyfill.d.ts
+++ b/src/types/event-source-polyfill.d.ts
@@ -1,0 +1,11 @@
+declare module 'event-source-polyfill' {
+  export class EventSourcePolyfill extends EventSource {
+    constructor(
+      url: string | URL,
+      init?: EventSourceInit & {
+        headers?: Record<string, string>
+        withCredentials?: boolean
+      }
+    )
+  }
+}


### PR DESCRIPTION
- 알림 SSE 스트리밍 api 구현

<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #102

## 📑 구현 사항

- 알림 SSE stream 훅 구현 

## 🌀 어려웠던 점 / 고민했던 부분

- 알림 목록을 주기적으로 갱신하는것이 아닌 새로운 알림은 SSE 채널을 구독하여 메세지 받아오는 구조를 너무 늦게 알았다..

## 📸 구현 이미지

-

## ❇️ 코드 설명

useNotificationStream: EventSourcePolyfill로 SSE 연결, 
Authorization 헤더 포함, 수신 시 알림 쿼리 갱신, 401 시 콜백 트리거
NotificationModal: 새 알림 수신 → refetch, 401 → getAccessTokenApi로 재발급, 실패 시 clearAuth
event-source-polyfill 타입 선언 추가로 TS 경고 제거

## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1.
