### PR TITLE
fix: 추천 강의 섹션 TypeError 해결 및 API 통합 (#104)

### DIFF
--- a/src/api/lecture.ts
+++ b/src/api/lecture.ts
@@ -23,6 +23,22 @@ export async function getLecturesApi(
   )
   return data
 }
+
+export async function getUserRecommendsLecturesApi(
+  params: LecturesParams = {}
+): Promise<LecturePageResponse> {
+  // 객체타입 Record<키값:키밸류>
+  const queryParams: Record<string, string | number> = {}
+
+  if (params.max_count) queryParams.max_count = params.max_count
+
+  const { data } = await axiosInstance.get<LecturePageResponse>(
+    '/v1/lectures/recommends',
+    { params: queryParams }
+  )
+  return data
+}
+
 /* 북마크 */
 export async function getBookmark(): Promise<BookmarkResponse> {
   const { data } = await axiosInstance.get(`/v1/lecture-bookmarks`)

--- a/src/components/lecture/LectureRecommendSection.tsx
+++ b/src/components/lecture/LectureRecommendSection.tsx
@@ -1,17 +1,10 @@
+import useUserRecommendLecture from '@/hooks/useUserRecommendLecture'
 import { useAuthStore } from '@/store/userStore'
-import type { Lecture } from '@/types/lecture'
 import { Badge } from '../common/badge'
 import LectureCard from './LectureCard'
 
-interface LectureRecommendSectionProps {
-  lectureList: Lecture[]
-}
-
-export default function LectureRecommendSection(
-  props: LectureRecommendSectionProps
-) {
-  const { lectureList } = props
-
+export default function LectureRecommendSection() {
+  const { data } = useUserRecommendLecture(3)
   /* 유저 상태 */
   const { user } = useAuthStore()
   return (
@@ -25,7 +18,7 @@ export default function LectureRecommendSection(
         </div>
 
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {lectureList?.slice(0, 3).map((i) => (
+          {data?.results.map((i) => (
             <LectureCard key={i.id} {...i}></LectureCard>
           ))}
         </div>

--- a/src/hooks/useUserRecommendLecture.ts
+++ b/src/hooks/useUserRecommendLecture.ts
@@ -1,0 +1,17 @@
+import { getUserRecommendsLecturesApi } from '@/api/lecture'
+import { useAuthStore } from '@/store/userStore'
+import { useQuery } from '@tanstack/react-query'
+
+export default function useUserRecommendLecture(max_count: number) {
+  const { loginState } = useAuthStore()
+  const { isPending, isError, error, data } = useQuery({
+    queryKey: ['lecture-recommend', max_count],
+    queryFn: async () => {
+      const data = await getUserRecommendsLecturesApi({ max_count }) //객체로 전달하기!!
+      return data
+    },
+    enabled: loginState === 'USER',
+  })
+
+  return { isError, isPending, error, data }
+}

--- a/src/mocks/handlers/lectures/lectureHandlers.ts
+++ b/src/mocks/handlers/lectures/lectureHandlers.ts
@@ -87,4 +87,31 @@ export const lectureHandlers = [
 
     return HttpResponse.json(response)
   }),
+
+  http.get('/api/v1/lectures/recommends', async ({ request }) => {
+    const url = new URL(request.url)
+    const maxCountParam = url.searchParams.get('max_count')
+    const maxCount = Math.min(
+      Math.max(parseInt(maxCountParam || '3'), 1), // 최소 1
+      10 // 최대 10
+    )
+
+    // 랜덤 추천 로직 (실제로는 사용자 관심사 기반)
+    const highRatedLectures = [...allLectures]
+
+    // 2. 랜덤 셔플
+    const shuffled = highRatedLectures.sort(() => Math.random() - 0.5)
+
+    // 3. max_count만큼 선택
+    const recommended = shuffled.slice(0, maxCount)
+
+    const response: LecturePageResponse = {
+      count: recommended.length,
+      next: null,
+      previous: null,
+      results: recommended,
+    }
+
+    return HttpResponse.json(response)
+  }),
 ]

--- a/src/pages/CoursesPage.tsx
+++ b/src/pages/CoursesPage.tsx
@@ -20,6 +20,8 @@ export default function Courses() {
   >()
   const [sort, setSort] = useState<LecturesParams['sort'] | undefined>()
 
+  //추천강의 불러오기
+
   //무한쿼리 불러오기
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useInfiniteScroll({
@@ -43,13 +45,6 @@ export default function Courses() {
     },
   })
 
-  //inView 변할 때 마다, 다음페이지 호출
-  // useEffect(() => {
-  //   if (inView && hasNextPage && !isFetchingNextPage) {
-  //     fetchNextPage()
-  //   }
-  // }, [inView, hasNextPage, isFetchingNextPage, fetchNextPage])
-
   /* 유저 상태 */
   const { loginState } = useAuthStore()
 
@@ -63,9 +58,7 @@ export default function Courses() {
           </p>
         </div>
         {loginState === 'USER' ? (
-          <LectureRecommendSection
-            lectureList={data?.pages.flatMap((page) => page.results) || []}
-          ></LectureRecommendSection>
+          <LectureRecommendSection />
         ) : (
           <GuestRecommendSection
             title="강의를"

--- a/src/types/lecture.ts
+++ b/src/types/lecture.ts
@@ -70,4 +70,5 @@ export interface LecturesParams {
     | 'it'
     | 'hardware'
     | 'design'
+  max_count?: number
 }


### PR DESCRIPTION

<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #104

## 📑 구현 사항
- 추천 강의 섹션에서 발생하던 배포 시 `TypeError` 해결 (강의 전용 API로 해결하였음)
- 추천 강의 전용 API 및 custom hook 구현

## 🌀 어려웠던 점 / 고민했던 부분
### 문제 상황
#### 배포 환경에서 추천 강의 섹션 렌더링 시 다음과 같은 TypeError 발생
```javascript
// 이전 빌드 코드
 {lectureList?.slice(0, 3).map((i) => (
```

### 원인
<img width="1385" height="660" alt="스크린샷 2025-12-22 오전 10 43 48" src="https://github.com/user-attachments/assets/29ecbc3b-790b-439b-9065-187c07a8e3ff" />

-  기존 추천 강의 불러오는 로직은, 전체강의에서 slice() 호출하는 형식이였다. 
- 로컬환경에서는 적용이 잘 되었지만, 배포 환경에서는 아이디값을 불러오지 못하여 타입에러가 발생하는 상황을 맞이하였다. 
> 어차피 추천강의 api 구현은 했어야 했기 때문에, 겸사겸사 추천 강의 전용 API 및 Hook 구현하였다. 

### 해결 방법

```tsx
export default function LectureRecommendSection() {
  /* 추천강의목록 호출 */
  const { data } = useUserRecommendLecture(3)
          {data?.results.map((i) => (
            <LectureCard key={i.id} {...i}></LectureCard>
          ))}
  )
}

```

1. `getUserRecommendsLecturesApi` 추가 ( 추천강의목록)
2. `useUserRecommendLecture` 커스텀훅(쿼리) 생성 
3. `max_count` 파라미터로 추천 강의 개수 제어 ( 반응형 레이아웃에 맞게 api호출하던지, slice할지 고민)

## ❇️ 코드 설명
### 추천 강의 api

```tsx
export async function getUserRecommendsLecturesApi(
  params: LecturesParams = {}
): Promise<LecturePageResponse> {
  // 객체타입 Record<키값:키밸류>
  const queryParams: Record<string, string | number> = {}

  if (params.max_count) queryParams.max_count = params.max_count

  const { data } = await axiosInstance.get<LecturePageResponse>(
    '/v1/lectures/recommends',
    { params: queryParams }
  )
  return data
}
```

- 서버에서 파라미터 값으로 max_count 설정받을 수 있따.
- 기본값은 3개다. 


### 강의 커스텀 훅 (리액트쿼리) 

```tsx
export default function useUserRecommendLecture(max_count: number) {
  const { loginState } = useAuthStore()
  const { isPending, isError, error, data } = useQuery({
    queryKey: ['lecture-recommend', max_count],
    queryFn: async () => {
      const data = await getUserRecommendsLecturesApi({ max_count }) //객체로 전달하기!!
      return data
    },
    enabled: loginState === 'USER',
  })

  return { isError, isPending, error, data }
}
```

- 쿼리키 설정 : lecture-recommend , 그리고 max_count 가 바뀔 때마다 캐싱 자동 요청 
- 쿼리함수 설정 : `getUserRecommendsLecturesApi` 를 비동기적으로 호출하여 max_count 객체로 전달
> 파라미터값은 무조건 객체형태로 전달해야함
- 비동기로 받은 쿼리함수의 데이터값을 반환하는 쿼리로직입니다.
- 해당 쿼리로직은 `loginState === 'USER'`경우에만 호출이 됩니다 (불필요한 api호출 방지함을 위함 ) 

## 💬 리뷰 요청사항
### 데스크탑버전 추천강의
<img width="1376" height="760" alt="스크린샷 2025-12-22 오전 11 17 32" src="https://github.com/user-attachments/assets/6445ec70-139e-4809-9914-4244098187d4" />


### 태블릿버전 추천강의
<img width="750" height="1257" alt="스크린샷 2025-12-22 오전 11 17 49" src="https://github.com/user-attachments/assets/01186061-7205-4f79-919d-7906c0b57f8f" />


### 모바일버전 추천강의
<img width="750" height="1257" alt="스크린샷 2025-12-22 오전 11 18 45" src="https://github.com/user-attachments/assets/cd5949c0-9c0a-4949-ab0d-66385a4f1e0a" />


### 추천강의목록에서 반응형 레이아웃 구성시 몇개씩 보여지는게 맞는가? 

- 이건, 다음 이슈 생성에 포함이 될 내용입니다 
- 현재 추천강의 목록은 홀수로 보여지기 때문에, 레이아웃 변동시 부자연스러운 부분이 있는건 사실입니다 
- 만약, 모바일뷰어시 추천강의를 1개만 보여주겠다? 는 조금 어색할 것 같다는 느낌도 들고 
- 모바일뷰어에도 추천강의 3개를 flex 로 나열하겠다 -> 라고 하면 카드 형태가 많이 슬림해질 것 같아서 가독성이 떨어지고 .... 

### 만약 차선책으로 모바일뷰어 추천강의가 1개만 랜더링이 된다면? 
- api호출을 3개에서 1개로 재호출을 해야하는지 vs 초기에 받아온 3개의 추천 강의 에서 제일 첫번째 값만 보여줘야하는지 고민입니다. 


