### PR TITLE
refactor,fix: 무료,할인가 카드 표시 수정 및 401 무한루프 해결(#56)

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -38,12 +38,33 @@ axiosInstance.interceptors.response.use(
 
     // 401: 토큰 갱신 후 재시도
     if (status === 401) {
-      try {
-        const access_token = await getAccessTokenApi()
-        useAuthStore.getState().setAccessToken(access_token)
-        originalRequest.headers.Authorization = `Bearer ${access_token}`
-        return axiosInstance(originalRequest) //헤더에 토큰 다시 넣어서 재요청
-      } catch (error) {
+      const { accessToken } = useAuthStore.getState()
+      // 재발급 시도 조건
+      if (accessToken) {
+        console.log('🔄 토큰 만료 감지: 토큰 갱신 시도...')
+
+        // 재시도 확인
+        //_retry가 이미 true인지 확인( 여기에선 당연히 undefined → false)
+        if (originalRequest._retry) {
+          console.log('⚠️ 이미 재시도한 요청입니다. 비회원으로 전환합니다.')
+          useAuthStore.getState().clearAuth()
+          return Promise.reject(error)
+        }
+
+        originalRequest._retry = true
+        try {
+          const access_token = await getAccessTokenApi()
+          useAuthStore.getState().setAccessToken(access_token)
+          originalRequest.headers.Authorization = `Bearer ${access_token}`
+          return axiosInstance(originalRequest) //헤더에 토큰 다시 넣어서 재요청
+        } catch (refreshError) {
+          console.log('⚠️ 토큰 재발급 실패: 비회원으로 전환합니다.')
+          useAuthStore.getState().clearAuth()
+          return Promise.reject(refreshError)
+        }
+      } else {
+        // 비회원 상태면 토큰 재발급 시도 없이 에러 반환
+        console.log('ℹ️ 비회원 상태입니다. 비회원으로 서비스를 이용합니다.')
         return Promise.reject(error)
       }
     }

--- a/src/components/lecture/LectureCard.tsx
+++ b/src/components/lecture/LectureCard.tsx
@@ -53,7 +53,7 @@ export default function LectureCard(lecture: Lecture) {
   const { loginState } = useAuthStore()
   /* 북마크 커스텀 상태 */
   const { addBookmarkMutation, deleteBookmarkMutation, getBookmarkQuery } =
-    useBookmark(loginState === 'USER')
+    useBookmark()
 
   const bookmarks = getBookmarkQuery.data?.results || []
   const isBookmarked = bookmarks.some((i) => i.id === id)

--- a/src/components/lecture/LectureCard.tsx
+++ b/src/components/lecture/LectureCard.tsx
@@ -83,9 +83,13 @@ export default function LectureCard(lecture: Lecture) {
         <CardAction className="absolute justify-between px-3 py-3">
           <div className="absolute top-2 flex flex-col gap-2">
             <Badge variant={'platform'}>{platform}</Badge>
-            <Badge variant={'discount'}>
-              {getDiscount(discounted_price, original_price)}% 할인
-            </Badge>
+            {getDiscount(discounted_price, original_price) !== null ? (
+              <Badge variant={'discount'}>
+                {getDiscount(discounted_price, original_price)}% 할인
+              </Badge>
+            ) : (
+              ''
+            )}
           </div>
           <Button
             variant="outline"
@@ -122,10 +126,18 @@ export default function LectureCard(lecture: Lecture) {
         <CardDescription>{instructor}</CardDescription>
         {getRatingStarsIcon(average_rating)}
         <div className="Card-Content-price flex items-center gap-2">
-          <h4>₩{discounted_price.toLocaleString('ko-KR')}</h4>
-          <h6 className="text-sm text-gray-400 line-through">
-            ₩{original_price.toLocaleString('ko-KR')}
-          </h6>
+          {discounted_price === 0 && original_price === 0 ? (
+            <h4>무료</h4>
+          ) : discounted_price === 0 ? (
+            <h4>₩{original_price.toLocaleString('ko-KR')}</h4>
+          ) : (
+            <>
+              <h4>₩{discounted_price.toLocaleString('ko-KR')}</h4>
+              <h6 className="text-sm text-gray-400 line-through">
+                ₩{original_price.toLocaleString('ko-KR')}
+              </h6>
+            </>
+          )}
         </div>
       </CardContent>
       <CardFooter className="relative">

--- a/src/helpers/getDiscount.ts
+++ b/src/helpers/getDiscount.ts
@@ -1,5 +1,9 @@
 export function getDiscount(discounted_price: number, original_price: number) {
-  return Math.floor(
-    ((original_price - discounted_price) / original_price) * 100
-  )
+  //discounted_price 0인경우
+  if (discounted_price !== 0) {
+    return Math.floor(
+      ((original_price - discounted_price) / original_price) * 100
+    )
+  }
+  return null
 }

--- a/src/hooks/useBookmark.ts
+++ b/src/hooks/useBookmark.ts
@@ -1,17 +1,19 @@
 import { addBookmark, deleteBookmark, getBookmark } from '@/api/lecture'
 import { showToast } from '@/components/common/toast/Toast'
+import { useAuthStore } from '@/store/userStore'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { AxiosError } from 'axios'
 /* 북마크 처리 커스텀 리액트쿼리 (로그인상태 boolean) */
-export function useBookmark(isLoggedIn: boolean) {
+export function useBookmark() {
   //queryClient 호출 invalidateQueries 사용 (캐시를 무효화 → 데이터 다시 fetch )
   const queryClient = useQueryClient()
+  const { loginState } = useAuthStore()
 
   //목록 불러오기
   const getBookmarkQuery = useQuery({
     queryKey: ['bookmarkList'],
     queryFn: getBookmark,
-    enabled: isLoggedIn,
+    enabled: loginState === 'USER',
   })
 
   //북마크 추가 useMutation (캐시무효화 사용되는 쿼리키)


### PR DESCRIPTION
<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #56
- Resolves #111

## 📑 구현 사항

- 무료/할인가 표시 로직 개선
- 401에러시 토큰재인증에 대한 플로우 정리해보기

## 🌀 어려웠던 점 / 고민했던 부분
- 로그인 유저와 게스트 유저가 공통으로 이용할 수 있는 서비스 처리 로직이 분명하지 않아서, 다시한번 코드를 점검하였습니다.
- 점검하면서, 인증 인가 플로우에 대해 다시한번 생각하게 되었습니다.

### 예시 1: 로그인 사용자의 토큰이 만료된 경우

1. 사용자가 App.tsx 첫 페이지 로드 
2. "마이페이지 me " API 호출하여 유저정보 받아와서 zustand저장하기 → 401 에러
3. 리프레쉬토큰 있음 → 액세스 토큰 재발급 시도
4. 새 토큰을 헤더에 넣고 "마이페이지 me " 재시도
5. 성공! 유저정보 zustand저장 

### 예시 2: 리프레시 토큰도 만료된 경우

1. 사용자가 App.tsx 첫 페이지 로드 → 401 에러
3. 리프레쉬토큰 없음 → clearAuth() 호출 → 비회원으로 전환
4. 에러 반환 → 화면에서 로그인 페이지로 이동 처리 가능

---

## 🌀 트러블슈팅
- 무한루프 해결하는 방법에 대하여 ,,, 
- [참고자료](https://velog.io/@overslept/React-Native-%EC%95%B1%EC%97%90%EC%84%9C-%ED%86%A0%ED%81%B0-%EA%B0%B1%EC%8B%A0-%EB%A1%9C%EC%A7%81-%EA%B5%AC%ED%98%84%ED%95%98%EA%B8%B0-401-%EC%98%A4%EB%A5%98-%ED%95%B4%EA%B2%B0)

### 무한루프 응애 
<img width="943" height="939" alt="스크린샷 2025-12-22 오후 4 04 52" src="https://github.com/user-attachments/assets/9b800a11-8035-46f7-9589-f7634d45d3f4" />

- 0.1초에 1개씩 날라가는중;;

### 해결
<img width="1526" height="1120" alt="image" src="https://github.com/user-attachments/assets/64c40994-cd4e-48ae-8dbc-4be7de4928c2" />

---

## 📸 구현 이미지
### 무료,할인가 수정 
<img width="992" height="834" alt="스크린샷 2025-12-22 오후 4 03 03" src="https://github.com/user-attachments/assets/82c16e17-9073-4808-b22c-b083a8f98b62" />
- 무료인 경우 금액 수정
- 할인가 없는 경우 , 배지 삭제함


## ❇️ 코드 설명
### 401 무한루프 
```tsx
        if (originalRequest._retry) {
          console.log('⚠️ 이미 재시도한 요청입니다. 비회원으로 전환합니다.')
          useAuthStore.getState().clearAuth()
          return Promise.reject(error)
        }

        originalRequest._retry = true
```
- ` originalRequest._retry` 를 분기처리로 넣었음
- 초기에는 originalRequest._retry 값 자체가 `undefined → false` 나오기 때문에 위 로직은 초기 랜더링시 실행이 안됨
- 그리고 나서, `originalRequest._retry = true` 를 만나게 됨으로써, 재호출 시도시 `   console.log('⚠️ 이미 재시도한 요청입니다. 비회원으로 전환합니다.')` 이 콘솔창에 뜨게 되면서, 루프를 막게 되는 로직임

### 401 인증처리 로직 수정
```tsx
 if (status === 401) {
      const { accessToken } = useAuthStore.getState()
      // 재발급 시도 조건
      if (accessToken) {
        console.log('🔄 토큰 만료 감지: 토큰 갱신 시도...')

        // 재시도 확인
        //_retry가 이미 true인지 확인( 여기에선 당연히 undefined → false)
        if (originalRequest._retry) {
          console.log('⚠️ 이미 재시도한 요청입니다. 비회원으로 전환합니다.')
          useAuthStore.getState().clearAuth()
          return Promise.reject(error)
        }

        originalRequest._retry = true
        try {
          const access_token = await getAccessTokenApi()
          useAuthStore.getState().setAccessToken(access_token)
          originalRequest.headers.Authorization = `Bearer ${access_token}`
          return axiosInstance(originalRequest) //헤더에 토큰 다시 넣어서 재요청
        } catch (refreshError) {
          console.log('⚠️ 토큰 재발급 실패: 비회원으로 전환합니다.')
          useAuthStore.getState().clearAuth()
          return Promise.reject(refreshError)
        }
      } else {
        // 비회원 상태면 토큰 재발급 시도 없이 에러 반환
        console.log('ℹ️ 비회원 상태입니다. 비회원으로 서비스를 이용합니다.')
        return Promise.reject(error)
      }
    }
```

1. 먼저 401 에러 발생시 `accessToken` 으로 값이 있는지 한번 더 확인 
2. `accessToken`이 있으면서 `originalRequest._retry` 있는지 더블체크 진행 
3.  재시도 한적이 없다면? `try..catch()` 를 통하여 `getAccessTokenApi()` 호출하여 토큰값 무사히 저장
4. 만약 토큰이 아예 없다면? `else` 문으로 내려가서 비회원 상태로 이용하게 됨. 

## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1. 현재 강의 목록중 카테고리 null 그리고 sort 기능 제대로 안되는 점 ( 가격 낮은순으로 필터링 걸면, 낮은순으로 안나옴 뒤죽박죽임) 백앤드 5팀에게 업무요청 날린 상황입니다 -> 내일중으로 마무리 작업 가능하도록 ,,,, 
2. 그리고 콘솔창에 호출이 2번되는 현상을 해결하기 위해선, 리액트의 `<StrictMode>` 를 해제하면 되는거 아닌가요? 계속 살리는 이유가 있을까요 ? 
