### PR TITLE
feat: useDebounce 구현 및 검색 결과 UX 개선 (#116)

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -38,12 +38,33 @@ axiosInstance.interceptors.response.use(
 
     // 401: 토큰 갱신 후 재시도
     if (status === 401) {
-      try {
-        const access_token = await getAccessTokenApi()
-        useAuthStore.getState().setAccessToken(access_token)
-        originalRequest.headers.Authorization = `Bearer ${access_token}`
-        return axiosInstance(originalRequest) //헤더에 토큰 다시 넣어서 재요청
-      } catch (error) {
+      const { accessToken } = useAuthStore.getState()
+      // 재발급 시도 조건
+      if (accessToken) {
+        console.log('🔄 토큰 만료 감지: 토큰 갱신 시도...')
+
+        // 재시도 확인
+        //_retry가 이미 true인지 확인( 여기에선 당연히 undefined → false)
+        if (originalRequest._retry) {
+          console.log('⚠️ 이미 재시도한 요청입니다. 비회원으로 전환합니다.')
+          useAuthStore.getState().clearAuth()
+          return Promise.reject(error)
+        }
+
+        originalRequest._retry = true
+        try {
+          const access_token = await getAccessTokenApi()
+          useAuthStore.getState().setAccessToken(access_token)
+          originalRequest.headers.Authorization = `Bearer ${access_token}`
+          return axiosInstance(originalRequest) //헤더에 토큰 다시 넣어서 재요청
+        } catch (refreshError) {
+          console.log('⚠️ 토큰 재발급 실패: 비회원으로 전환합니다.')
+          useAuthStore.getState().clearAuth()
+          return Promise.reject(refreshError)
+        }
+      } else {
+        // 비회원 상태면 토큰 재발급 시도 없이 에러 반환
+        console.log('ℹ️ 비회원 상태입니다. 비회원으로 서비스를 이용합니다.')
         return Promise.reject(error)
       }
     }

--- a/src/components/common/Loading.tsx
+++ b/src/components/common/Loading.tsx
@@ -1,7 +1,7 @@
 import LoadingUi from '@/assets/images/loading.png'
 export default function Loading() {
   return (
-    <div className="h-[278px] w-[854px] justify-center rounded-2xl border border-gray-200 bg-gray-50 p-[25px] text-center">
+    <div className="h-[278px] justify-center rounded-2xl border border-gray-200 bg-gray-50 p-[25px] text-center">
       <div className="flex h-full flex-col items-center justify-center px-[210px] text-center">
         <div className="pb-[24px]">
           <div className="flex items-center justify-center pt-12 pb-6">

--- a/src/components/common/Select.tsx
+++ b/src/components/common/Select.tsx
@@ -36,18 +36,20 @@ export default function Select({
 }: SelectProps) {
   return (
     <div className="flex w-full flex-col">
-      <Label htmlFor={name}>
-        {required ? (
-          <div className="mb-2 flex gap-1 text-sm font-medium text-gray-700">
-            <p> {title}</p>
-            <p className="text-red-500">*</p>
-          </div>
-        ) : (
-          <div className="mb-2 flex gap-1 text-sm font-medium text-gray-700">
-            <p> {title}</p>
-          </div>
-        )}
-      </Label>
+      {title && (
+        <Label htmlFor={name}>
+          {required ? (
+            <div className="mb-2 flex gap-1 text-sm font-medium text-gray-700">
+              <p> {title}</p>
+              <p className="text-red-500">*</p>
+            </div>
+          ) : (
+            <div className="mb-2 flex gap-1 text-sm font-medium text-gray-700">
+              <p> {title}</p>
+            </div>
+          )}
+        </Label>
+      )}
       <SelectField
         name={name}
         value={value}

--- a/src/components/common/header/User.tsx
+++ b/src/components/common/header/User.tsx
@@ -1,5 +1,6 @@
 import notificationIcon from '@/assets/icons/notification.svg'
 import topArrow from '@/assets/icons/topArrow.svg'
+import defaultImg from '@/assets/images/defaultProfileImg.svg'
 import useIsDesktop from '@/hooks/useIsDesktop'
 
 import { AnimatePresence } from 'framer-motion'
@@ -91,9 +92,9 @@ function User() {
       >
         <div className="flex h-8 w-8 items-center justify-center overflow-hidden rounded-full bg-[#FEF9C3]">
           <img
-            src={user?.profile_img_url}
+            src={user?.profile_img_url ? user?.profile_img_url : defaultImg}
             alt="profileIcon"
-            className="object-contain"
+            className="h-full w-full object-cover"
           />
         </div>
         <div className="text-primary-600 text-base">{user?.name}</div>

--- a/src/components/common/layout/Layout.tsx
+++ b/src/components/common/layout/Layout.tsx
@@ -6,12 +6,12 @@ import { Outlet } from 'react-router'
 function Layout() {
   const [isSideBarOpen, setIsSideBarOpen] = useState(false)
   return (
-    <div className="bg-gray-50">
+    <div className="flex min-h-dvh flex-col bg-gray-50">
       <Header
         isSideBarOpen={isSideBarOpen}
         setIsSideBarOpen={setIsSideBarOpen}
       />
-      <main className="wrapper">
+      <main className="wrapper flex-1">
         <Outlet />
       </main>
       <Footer />

--- a/src/components/notFound/NoSearchResult.tsx
+++ b/src/components/notFound/NoSearchResult.tsx
@@ -5,7 +5,7 @@ type searchResultProps = {
 }
 export default function NoSearchResult({ searchResult }: searchResultProps) {
   return (
-    <div className="h-[382px] w-full justify-center rounded-2xl border border-gray-200 bg-gray-50 p-[25px] text-center md:w-[854px]">
+    <div className="h-[382px] w-full justify-center rounded-2xl border border-gray-200 bg-gray-50 p-[25px] text-center">
       <div className="flex h-full flex-col items-center justify-center text-center">
         <div className="mb-6">
           <div className="flex h-20 w-20 items-center justify-center rounded-full bg-gray-100">

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react'
+
+//useDebounce 기본값은 2초
+const useDebounce = <T>(value: T, delay: number = 500): T => {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value)
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedValue(value), delay || 2000)
+
+    return () => {
+      clearTimeout(timer)
+    }
+  }, [value, delay])
+
+  return debouncedValue
+}
+
+export default useDebounce

--- a/src/pages/CoursesPage.tsx
+++ b/src/pages/CoursesPage.tsx
@@ -4,6 +4,7 @@ import GuestRecommendSection from '@/components/common/GuestRecommendSection'
 import { Input } from '@/components/input'
 import LectureList from '@/components/lecture/LectureList'
 import LectureRecommendSection from '@/components/lecture/LectureRecommendSection'
+import NoSearchResult from '@/components/notFound/NoSearchResult'
 import useInfiniteScroll from '@/hooks/quries/useInfiniteScroll'
 import { categoryData, sortData } from '@/mappers/lectures/lecture'
 import { useAuthStore } from '@/store/userStore'
@@ -34,6 +35,10 @@ export default function Courses() {
           sort,
         }),
     })
+
+  // 검색어 결과값 있는지 확인
+  const hasNoResult = data?.pages.every((page) => page.results.length === 0)
+  console.log('검색어 없으면 true hasNoResult?', hasNoResult)
   //무한스크롤
   const { ref } = useInView({
     threshold: 0,
@@ -102,8 +107,14 @@ export default function Courses() {
           }}
         ></Select>
       </section>
+
       <section className="courses_cardlist">
-        <LectureList data={data}></LectureList>
+        {/* 검색결과 없으면 NoSearchResult */}
+        {hasNoResult ? (
+          <NoSearchResult searchResult={inputValue} />
+        ) : (
+          <LectureList data={data}></LectureList>
+        )}
       </section>
       {!hasNextPage ? (
         <div className="flex-center mt-12 h-12 rounded-md bg-gray-400 text-center text-white">

--- a/src/pages/CoursesPage.tsx
+++ b/src/pages/CoursesPage.tsx
@@ -1,11 +1,13 @@
 import { getLecturesApi } from '@/api/lecture'
 import { Select } from '@/components/common'
 import GuestRecommendSection from '@/components/common/GuestRecommendSection'
+import Loading from '@/components/common/Loading'
 import { Input } from '@/components/input'
 import LectureList from '@/components/lecture/LectureList'
 import LectureRecommendSection from '@/components/lecture/LectureRecommendSection'
 import NoSearchResult from '@/components/notFound/NoSearchResult'
 import useInfiniteScroll from '@/hooks/quries/useInfiniteScroll'
+import useDebounce from '@/hooks/useDebounce'
 import { categoryData, sortData } from '@/mappers/lectures/lecture'
 import { useAuthStore } from '@/store/userStore'
 import type { LecturesParams } from '@/types/lecture'
@@ -20,25 +22,22 @@ export default function Courses() {
     LecturesParams['category'] | undefined
   >()
   const [sort, setSort] = useState<LecturesParams['sort'] | undefined>()
-
-  //추천강의 불러오기
-
+  //useDebounce 적용
+  const debouncedInputValue = useDebounce(inputValue)
   //무한쿼리 불러오기
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
     useInfiniteScroll({
-      queryKey: ['lectures', inputValue, category, sort],
+      queryKey: ['lectures', debouncedInputValue, category, sort],
       queryFn: (page) =>
         getLecturesApi({
           page,
-          search: inputValue,
+          search: debouncedInputValue,
           category, // 이미 undefined면 그대로
           sort,
         }),
     })
-
   // 검색어 결과값 있는지 확인
   const hasNoResult = data?.pages.every((page) => page.results.length === 0)
-  console.log('검색어 없으면 true hasNoResult?', hasNoResult)
   //무한스크롤
   const { ref } = useInView({
     threshold: 0,
@@ -71,7 +70,7 @@ export default function Courses() {
           ></GuestRecommendSection>
         )}
       </section>
-      <section className="courses_filter flex flex-col gap-2 rounded-md border border-gray-200 bg-white p-6 sm:flex-row">
+      <section className="courses_filter flex flex-col items-center gap-2 rounded-md border border-gray-200 bg-white p-6 sm:flex-row">
         <Input
           prefix={<Search />}
           className="h-[38px]"
@@ -107,22 +106,24 @@ export default function Courses() {
           }}
         ></Select>
       </section>
-
-      <section className="courses_cardlist">
-        {/* 검색결과 없으면 NoSearchResult */}
-        {hasNoResult ? (
-          <NoSearchResult searchResult={inputValue} />
-        ) : (
-          <LectureList data={data}></LectureList>
-        )}
-      </section>
-      {!hasNextPage ? (
+      {isLoading ? (
+        <Loading></Loading>
+      ) : (
+        <section className="courses_cardlist">
+          {/* 검색결과 없으면 NoSearchResult */}
+          {hasNoResult ? (
+            <NoSearchResult searchResult={debouncedInputValue} />
+          ) : (
+            <LectureList data={data}></LectureList>
+          )}
+        </section>
+      )}
+      {!hasNoResult && !hasNextPage && (
         <div className="flex-center mt-12 h-12 rounded-md bg-gray-400 text-center text-white">
           더 이상 강의가 없습니다.
         </div>
-      ) : (
-        <div ref={ref}></div>
       )}
+      {!hasNoResult && hasNextPage && <div ref={ref}></div>}
     </div>
   )
 }


### PR DESCRIPTION
<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #115 (체리픽)
-  Resolves #116 

## 📑 구현 사항
### 1. 검색 성능 최적화 - useDebounce 훅 구현

- 검색어 입력 시 0.5초 디바운스 적용으로 불필요한 API 호출 방지
- delay 옵션 설정 가능 _**(기본값 500ms)**_
- React Query의 queryKey에 디바운스된 값 사용
- [참고자료](https://velog.io/@hwisaac/Debounce-%ED%9B%85)

### 2. 검색 결과 UX 개선

- `NoSearchResult` 컴포넌트: 검색 결과가 없을 때 사용자 친화적 메시지 표시
- `Loading` 컴포넌트: 검색 중 로딩 상태 표시
- 1팀에서 제작한 공통컴포넌트의 고정 너비값 제거로 반응형 대응 개선하였음.

### 3. 401 에러 처리 로직 개선
- 로그인 상태(accessToken 보유) 시에만 토큰 재발급 API 호출
- 비회원은 토큰 재발급 시도 없이 바로 서비스 이용 가능
- 만약, 토큰 재발급 실패 시 자동으로 비회원 상태 전환 (clearAuth())
- 무한 재시도 방지 로직 추가 **`(_retry 플래그)`**
- **`axios`** **`timeout 5초 설정`** [axios config](https://axios-http.com/kr/docs/config_defaults)
- 타임아웃 5초를 설정하여 , 5초 지나면 catch문으로 에러 보내기 [참고블로그](https://velog.io/@boyeon_jeong/Axios-%ED%83%80%EC%9E%84%EC%95%84%EC%9B%83-%EC%84%A4%EC%A0%95%ED%95%98%EA%B8%B0)

### 4. UI/UX 개선

- Select 컴포넌트: title prop이 없을 때 불필요한 label 태그 높이 제거
- 네비게이션 유저 프로필: 16:9 이미지 업로드 시 여백 발생 문제 수정 (object-cover 적용)
- Footer: 레이아웃 flex 구조로 개선하여 **모든 해상도에서 하단 고정**

## 🌀 어려웠던 점 / 고민했던 부분
### 1. 토큰 재발급 로직

#### 문제: 리프레시 토큰은 HTTP-only 쿠키에 저장되어 JavaScript에서 직접 확인 불가
#### 고민: 비회원인지 로그인 사용자인지 어떻게 판단할 것인가?
#### 해결: accessToken의 존재 여부로 로그인 상태 판단

1. accessToken이 있으면 → 로그인했던 사용자 → 토큰 재발급 시도
2. accessToken이 없으면 → 비회원 → 재발급 시도 없이 에러 반환

### 2. 무한 재시도 방지
#### 문제: 토큰 재발급 성공 후 재요청도 401이 나는 경우 무한 루프 발생 가능
#### 해결: originalRequest._retry 플래그 사용

1. 첫 401: _retry가 undefined(falsy) → 재발급 시도 → _retry = true 설정
2. 두 번째 401: _retry가 true → 비회원 전환 후 에러 반환

## 📸 구현 이미지
### 프로필 이미지 변경 전
<img width="656" height="194" alt="스크린샷 2025-12-23 오전 11 42 38" src="https://github.com/user-attachments/assets/960cc8c8-b4ee-4b32-8415-2ca2cf2872c0" />

### 프로필 이미지 변경 후 
<img width="520" height="171" alt="스크린샷 2025-12-23 오전 11 42 32" src="https://github.com/user-attachments/assets/cbcf958d-2a3d-4a73-bb63-9e6c77367e0e" />

### Select 컴포넌트 label 전
<img width="911" height="102" alt="스크린샷 2025-12-23 오후 12 02 50" src="https://github.com/user-attachments/assets/3c58c8a3-f782-47a2-a5f8-4971806e2bc2" />

### Select 컴포넌트 label 옵셔널 랜더링 후
<img width="1354" height="358" alt="스크린샷 2025-12-23 오전 11 34 07" src="https://github.com/user-attachments/assets/787af453-e32f-475d-9c06-98c850ce21c6" />

### 검색어 없음 및 footer 바닥에 고정
<img width="1251" height="1289" alt="스크린샷 2025-12-23 오전 11 33 29" src="https://github.com/user-attachments/assets/83b58e15-46a5-4aae-a456-e462019bcd8a" />

### 강의목록 로딩중 페이지 
![검색어로딩중](https://github.com/user-attachments/assets/b2352849-def5-489c-94e7-bd3e0adc1c04)


### 비회원인 경우 콘솔창
<img width="2242" height="1122" alt="image" src="https://github.com/user-attachments/assets/61edda7f-958c-4dfc-8fd5-930b2f40e8a2" />

### useDebounce
![디바운스](https://github.com/user-attachments/assets/27761e6f-1ed5-48bb-873d-59148752b48b)



## ❇️ 코드 설명
### 401 에러 발생 시 토큰 재발급
```tsx
// 1. accessToken 확인으로 로그인 여부 판단
const { accessToken } = useAuthStore.getState()

if (accessToken) {
  // 2. 무한 루프 방지 - 이미 재시도했는지 체크
  if (originalRequest._retry) {
    clearAuth()  // 비회원 전환
    return Promise.reject(error)
  }
  
  // 3. 재시도 플래그 설정 후 토큰 재발급
  originalRequest._retry = true
  const access_token = await getAccessTokenApi()
  
  // 4. 새 토큰으로 원래 요청 재시도
  return axiosInstance(originalRequest)
} else {
  // 비회원은 재발급 없이 바로 에러 반환
  return Promise.reject(error)
}
```
1. accessToken 을 store에서 꺼내옴 
2. accessToken 있으면 토큰 재발급 로직 설정  (getAccessTokenApi)
3. accessToken 없으면 토큰 재발급 없이, 에러로 반환시킴 

### useDebounce
```tsx
const debouncedInputValue = useDebounce(inputValue, 500)

// React Query에 디바운스된 값 전달
useQuery({
  queryKey: ['lectures', debouncedInputValue],
  queryFn: () => getLectureList({ title: debouncedInputValue })
})
```
- `useDebounce` 훅을 불러와서, 인자로 사용자 입력한 검색어를 넣어준다. 
- 0.5초 후에 입력된 값을 `debouncedInputValue`에 저장하였다. 
- 디바운스된 값을 리액트쿼리에 전달하였다. 


## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1. 401 무한루프 수정에 대한 피드백 부탁드립니다.
2. 그리고 비회원인 경우 토큰 재발급 없이, 에러 반환(`return Promise.reject(error)`)으로 처리하였습니다만. 
제 생각엔 에러 반환이 아니라 반환하지 않고 `return ` 하는건 어떨까요??
비회원인경우에도 네트워크탭에 401에러가 계속 뜨고있어서 ;; 이걸 해결하고자 제안해봅니다.
<img width="1845" height="1522" alt="스크린샷 2025-12-23 오후 1 31 05" src="https://github.com/user-attachments/assets/3f333a4e-1a74-46d4-bf00-7e89a2a70235" />


