### PR TITLE
fix: presign_url api 에러 수정

### DIFF
--- a/src/hooks/useWriteRecruitmentForm.ts
+++ b/src/hooks/useWriteRecruitmentForm.ts
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router'
 import { useQuery } from '@tanstack/react-query'
 import { z } from 'zod'
 import { getStudyGroupDetail, getStudyGroups } from '@/api/studyGroup'
-import { getPresignedUrl } from '@/api/uploads'
+import { getPresignedUrl, uploadToPresigned } from '@/api/uploads'
 import { showToast } from '@/components/common/toast/Toast'
 import { axiosInstance } from '@/api/axios'
 import type { UploadedFile } from '@/components/common/uploader/FileUploader'
@@ -41,7 +41,7 @@ export function useWriteRecruitmentForm() {
   const [title, setTitle] = useState('')
   const [estimatedFee, setEstimatedFee] = useState('')
   const [imageCount, setImageCount] = useState(0)
-  const [imageUrls, setImageUrls] = useState<string[]>([])
+  const [imageKeys, setImageKeys] = useState<string[]>([])
   const [tagIds, setTagIds] = useState<number[]>([])
   const [studyGroupId, setStudyGroupId] = useState<string>('')
   const [expectedHeadcount, setExpectedHeadcount] = useState<string>('')
@@ -95,24 +95,26 @@ export function useWriteRecruitmentForm() {
   }
 
   const onUploadImage = async (file: File) => {
-    const ext = file.name.split('.').pop() ?? 'png'
+    const ext = (file.name.split('.').pop() ?? 'png').toLowerCase()
+    const contentType = file.type || 'application/octet-stream'
     const presigned = await getPresignedUrl({
       type: 'RECRUITMENT_IMAGE',
-      content_type: file.type,
-      file_name: file.name.replace(`.${ext}`, ''),
+      content_type: contentType,
+      file_name: file.name, // 확장자 포함 원본 이름 그대로 전송
       file_ext: ext,
     })
-    // TODO: presigned.upload_url로 실제 이미지를 PUT 전송한 뒤 성공 시 file_url을 사용하도록 연동 필요
-    setImageUrls((prev) => [...prev, presigned.file_url])
+    await uploadToPresigned(presigned.upload_url, file, presigned.headers)
+    setImageKeys((prev) => [...prev, presigned.key])
     return presigned.file_url
   }
 
   const onUploadFile = async (file: File) => {
-    const ext = file.name.split('.').pop() ?? 'dat'
+    const ext = (file.name.split('.').pop() ?? 'dat').toLowerCase()
+    const contentType = file.type || 'application/octet-stream'
     const presigned = await getPresignedUrl({
       type: 'RECRUITMENT_ATTACHMENT',
-      content_type: file.type || 'application/octet-stream',
-      file_name: file.name.replace(`.${ext}`, ''),
+      content_type: contentType,
+      file_name: file.name, // 확장자 포함 원본 이름 그대로 전송
       file_ext: ext,
     })
     // TODO: presigned.upload_url로 실제 파일을 PUT 업로드하도록 백엔드 연동 필요
@@ -141,7 +143,7 @@ export function useWriteRecruitmentForm() {
       close_at: formatCloseAt(deadline),
       estimated_fee: estimatedFee ? Number(estimatedFee) : undefined,
       tags: tagIds.length ? tagIds : undefined,
-      image_urls: imageUrls,
+      image_urls: imageKeys,
       files: uploadedFiles.map((f) => ({
         file_name: f.name,
         file_url: f.url,
@@ -175,6 +177,7 @@ export function useWriteRecruitmentForm() {
     expectedHeadcount,
     uploadedFiles,
     tagIds,
+    imageKeys,
   }
 
   const actions = {

--- a/src/hooks/useWriteRecruitmentForm.ts
+++ b/src/hooks/useWriteRecruitmentForm.ts
@@ -117,7 +117,7 @@ export function useWriteRecruitmentForm() {
       file_name: file.name, // 확장자 포함 원본 이름 그대로 전송
       file_ext: ext,
     })
-    // TODO: presigned.upload_url로 실제 파일을 PUT 업로드하도록 백엔드 연동 필요
+    await uploadToPresigned(presigned.upload_url, file, presigned.headers)
     return presigned.file_url
   }
 


### PR DESCRIPTION
<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #125 

## 📑 구현 사항

- 마크다운, 첨부파일에 적용된 presign_url api 사용구조 수정

## 🌀 어려웠던 점 / 고민했던 부분

- 

## 📸 구현 이미지

- 
<img width="1258" height="489" alt="image" src="https://github.com/user-attachments/assets/c0b0b739-dde0-4507-9896-9eb78bcb2efd" />
<img width="1249" height="576" alt="image" src="https://github.com/user-attachments/assets/9820fc65-3919-4ab9-8d4b-01d7eee8c71e" />
<img width="1191" height="279" alt="image" src="https://github.com/user-attachments/assets/cc7d36d2-d305-40b7-b924-ec444590d87d" />


## ❇️ 코드 설명

- todo로 남겨둔 put 요청 구현
- presigned-url api 리퀘스트 형태 api 스펙에 맞게 수정 (file_name)

## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1.
