### PR TITLE
fix,feat 공고 작성, 수정 api 로직 수정 (#125, #127)

### DIFF
--- a/src/components/common/uploader/FileUploader.tsx
+++ b/src/components/common/uploader/FileUploader.tsx
@@ -30,12 +30,6 @@ export function FileUploader({
 }: FileUploaderProps) {
   const remain = Math.max(0, maxCount - files.length)
 
-  const formatSize = (bytes: number) => {
-    if (bytes >= 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(1)} MB`
-    if (bytes >= 1024) return `${(bytes / 1024).toFixed(1)} KB`
-    return `${bytes} B`
-  }
-
   const handleDrop = async (accepted: File[], rejected: FileRejection[]) => {
     rejected.forEach((rej) => {
       const reason =
@@ -192,7 +186,7 @@ export function FileUploader({
                 <X size={14} />
               </Button>
               <div className="mt-1 px-1 text-[11px] text-gray-500">
-                {file.type || 'unknown'} · {formatSize(file.size)}
+                {file.name}
               </div>
             </div>
           ))}

--- a/src/components/common/uploader/FileUploader.tsx
+++ b/src/components/common/uploader/FileUploader.tsx
@@ -8,7 +8,8 @@ export type UploadedFile = {
   id: string
   name: string
   size: number
-  url: string
+  url: string // 미리보기용 URL
+  key?: string // 서버 전송용 key
   type: string
 }
 
@@ -17,7 +18,7 @@ type FileUploaderProps = {
   onChange: (next: UploadedFile[]) => void
   maxCount?: number
   maxSize?: number
-  onUploadFile?: (file: File) => Promise<string>
+  onUploadFile?: (file: File) => Promise<{ previewUrl: string; key: string }>
 }
 
 export function FileUploader({
@@ -57,9 +58,12 @@ export function FileUploader({
     for (let i = 0; i < sliceEnd; i += 1) {
       const file = accepted[i]
       let url = URL.createObjectURL(file)
+      let key: string | undefined = undefined
       if (onUploadFile) {
         try {
-          url = await onUploadFile(file)
+          const uploaded = await onUploadFile(file)
+          url = uploaded.previewUrl
+          key = uploaded.key
         } catch (err) {
           showToast.error('파일 업로드 실패', (err as Error)?.message ?? '')
           continue
@@ -71,6 +75,7 @@ export function FileUploader({
         size: file.size,
         type: file.type,
         url,
+        key,
       })
     }
 

--- a/src/components/postings/manage/ManageHeader.tsx
+++ b/src/components/postings/manage/ManageHeader.tsx
@@ -1,13 +1,22 @@
 import { Button } from '@/components/common'
 import { ArrowLeft, Plus } from 'lucide-react'
 
-export default function ManageHeader() {
+type ManageHeaderProps = {
+  onClickWrite?: () => void
+  onClickBack?: () => void
+}
+
+export default function ManageHeader({
+  onClickWrite,
+  onClickBack,
+}: ManageHeaderProps) {
   return (
     <div className="flex-between flex-col gap-8 md:flex-row">
       <div className="flex-center mr-auto gap-4">
         <Button
           variant="ghost"
           className="h-10 w-10 cursor-pointer rounded-full bg-gray-100 hover:bg-gray-200"
+          onClick={onClickBack}
         >
           <ArrowLeft className="h-6 w-6" />
         </Button>
@@ -21,6 +30,7 @@ export default function ManageHeader() {
       <Button
         variant="primary"
         className="mr-auto w-full cursor-pointer md:mr-0 md:w-fit"
+        onClick={onClickWrite}
       >
         <Plus className="h-6 w-6" /> 새 공고 작성하기
       </Button>

--- a/src/components/postings/write/WriteForm.tsx
+++ b/src/components/postings/write/WriteForm.tsx
@@ -8,8 +8,14 @@ import TagSvg from '@/assets/icons/Tag.svg'
 import { FileUploader } from '@/components/common/uploader/FileUploader'
 import { useWriteRecruitmentForm } from '@/hooks/useWriteRecruitmentForm'
 import { TagSelectModal, type TagOption } from './TagSelectModal'
-import { useEffect, useState, type Dispatch, type SetStateAction } from 'react'
-import { useSearchParams } from 'react-router-dom'
+import {
+  useEffect,
+  useRef,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from 'react'
+import { useSearchParams, useLocation, useNavigate } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import { getRecruitmentDetail } from '@/api/recruitments'
 import { getLecturesApi } from '@/api/lecture'
@@ -180,11 +186,13 @@ function ExtraInfoSection({
   actions,
   selectedTags,
   setSelectedTags,
+  totalLecturePrice,
   isTagModalOpen,
   onOpenTagModal,
 }: ExtraInfoProps & {
   isTagModalOpen: boolean
   onOpenTagModal: (open: boolean) => void
+  totalLecturePrice: number
 }) {
   const { estimatedFee, uploadedFiles } = state
   const { setEstimatedFee, setUploadedFiles, onUploadFile, setTagIds } = actions
@@ -204,6 +212,11 @@ function ExtraInfoSection({
           name="estimated_fee"
           value={estimatedFee}
           onChange={(e) => setEstimatedFee(e.target.value)}
+          onBlur={() => {
+            if (estimatedFee !== '') return
+            const fallback = totalLecturePrice > 0 ? totalLecturePrice : 0
+            setEstimatedFee(String(fallback))
+          }}
         />
       </div>
       <div>
@@ -294,12 +307,18 @@ function ExtraInfoSection({
 }
 
 export default function WriteForm() {
-  const { state, actions, options } = useWriteRecruitmentForm()
   const [selectedTags, setSelectedTags] = useState<TagOption[]>([])
   const [isTagModalOpen, setIsTagModalOpen] = useState(false)
   const [initialized, setInitialized] = useState(false)
   const [searchParams] = useSearchParams()
+  const navigate = useNavigate()
+  const location = useLocation()
   const recruitmentId = searchParams.get('recruitmentId')
+  const isEditing = location.pathname.includes('/edit') || !!recruitmentId
+  const { state, actions, options } = useWriteRecruitmentForm(
+    recruitmentId || undefined,
+    isEditing
+  )
   const {
     setTitle,
     setContent,
@@ -336,13 +355,19 @@ export default function WriteForm() {
         close_at: string
         tags: { id: number; name: string }[]
         image_urls?: string[]
+        study_group?: number
+        files?: { file_name: string; file_url: string }[]
       }
     | undefined
   >({
     queryKey: ['my-recruitment-detail', recruitmentId],
     queryFn: async () => {
       if (!recruitmentId) return undefined
-      return getRecruitmentDetail(recruitmentId)
+      const res = await getRecruitmentDetail(recruitmentId)
+      // 디버깅용: 상세 데이터 확인
+      // eslint-disable-next-line no-console
+      console.log('Recruitment detail', res)
+      return res
     },
     enabled: !!recruitmentId,
   })
@@ -357,14 +382,60 @@ export default function WriteForm() {
     0
   )
 
+  // 그룹이 선택된 상태라면 강의 합계(없으면 0)로 예상비용을 자동 세팅
+  useEffect(() => {
+    if (!state.studyGroupId) return
+    const fallback = totalLecturePrice > 0 ? totalLecturePrice : 0
+    setEstimatedFee(String(fallback))
+  }, [state.studyGroupId, totalLecturePrice, setEstimatedFee])
+
+  // 스터디 그룹 변경 시 강의 합계로 예상 비용 자동 입력 (강의 없으면 0)
+  const prevGroupIdRef = useRef(state.studyGroupId)
+  useEffect(() => {
+    if (!state.studyGroupId) return
+    if (prevGroupIdRef.current !== state.studyGroupId) {
+      const fallback = totalLecturePrice > 0 ? totalLecturePrice : 0
+      actions.setEstimatedFee(String(fallback))
+      prevGroupIdRef.current = state.studyGroupId
+    }
+  }, [state.studyGroupId, totalLecturePrice, actions])
+
   useEffect(() => {
     if (!detail || initialized) return
     setTitle(detail.title)
     setContent(detail.content)
-    setEstimatedFee(detail.estimated_fee ? String(detail.estimated_fee) : '')
+    setEstimatedFee(
+      detail.estimated_fee !== undefined ? String(detail.estimated_fee) : ''
+    )
     setExpectedHeadcount(
       detail.expected_headcount ? String(detail.expected_headcount) : ''
     )
+    if (detail.study_group) {
+      actions.setStudyGroupId(String(detail.study_group))
+    }
+    if (detail.files?.length) {
+      const presetFiles = detail.files.map((f, idx) => {
+        const lower = f.file_name.toLowerCase()
+        let type = 'application/octet-stream'
+        if (lower.match(/\.(png|jpe?g|webp)$/)) type = 'image/'
+        else if (lower.endsWith('.pdf')) type = 'application/pdf'
+        return {
+          id: `${f.file_name}-${idx}`,
+          name: f.file_name,
+          size: 0,
+          type,
+          url: f.file_url,
+        }
+      })
+      actions.setUploadedFiles(presetFiles)
+      actions.setOriginalFileUrls(detail.files.map((f) => f.file_url))
+    }
+    if (detail.image_urls) {
+      const urls = Array.isArray(detail.image_urls)
+        ? detail.image_urls
+        : [detail.image_urls]
+      actions.setImageUrls(urls.filter(Boolean))
+    }
     setTagIds(detail.tags?.map((t) => t.id) ?? [])
     setSelectedTags(
       detail.tags?.map((t) => ({ id: String(t.id), name: t.name })) ?? []
@@ -400,15 +471,21 @@ export default function WriteForm() {
         actions={actions}
         selectedTags={selectedTags}
         setSelectedTags={setSelectedTags}
+        totalLecturePrice={totalLecturePrice}
         isTagModalOpen={isTagModalOpen}
         onOpenTagModal={setIsTagModalOpen}
       />
       <section className="my-8 flex justify-end gap-4 border-t border-gray-200 pt-[25px]">
-        <Button variant="outline" type="button" className="px-6 py-3">
+        <Button
+          variant="outline"
+          type="button"
+          className="px-6 py-3"
+          onClick={() => navigate(-1)}
+        >
           취소
         </Button>
         <Button variant="primary" type="submit" className="px-6 py-3">
-          공고 등록
+          {isEditing ? '공고 수정' : '공고 등록'}
         </Button>
       </section>
     </form>

--- a/src/components/postings/write/WriteForm.tsx
+++ b/src/components/postings/write/WriteForm.tsx
@@ -370,6 +370,9 @@ export default function WriteForm() {
       return res
     },
     enabled: !!recruitmentId,
+    staleTime: 0, // 페이지 진입 시마다 최신 정보 조회
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
   })
 
   const formattedLectures = lectureDetails.map((lec) => ({
@@ -415,10 +418,15 @@ export default function WriteForm() {
     }
     if (detail.files?.length) {
       const presetFiles = detail.files.map((f, idx) => {
-        const lower = f.file_name.toLowerCase()
+        const lowerName = f.file_name.toLowerCase()
+        const lowerUrl = f.file_url.toLowerCase()
+        const isImage =
+          /\.(png|jpe?g|webp)$/.test(lowerName) ||
+          /\.(png|jpe?g|webp)$/.test(lowerUrl)
+        const isPdf = lowerName.endsWith('.pdf') || lowerUrl.endsWith('.pdf')
         let type = 'application/octet-stream'
-        if (lower.match(/\.(png|jpe?g|webp)$/)) type = 'image/'
-        else if (lower.endsWith('.pdf')) type = 'application/pdf'
+        if (isImage) type = 'image/'
+        else if (isPdf) type = 'application/pdf'
         return {
           id: `${f.file_name}-${idx}`,
           name: f.file_name,
@@ -428,7 +436,6 @@ export default function WriteForm() {
         }
       })
       actions.setUploadedFiles(presetFiles)
-      actions.setOriginalFileUrls(detail.files.map((f) => f.file_url))
     }
     if (detail.image_urls) {
       const urls = Array.isArray(detail.image_urls)

--- a/src/components/postings/write/WriteHeader.tsx
+++ b/src/components/postings/write/WriteHeader.tsx
@@ -1,22 +1,32 @@
 import { Button } from '@/components/common'
 import { ArrowLeft } from 'lucide-react'
+import { useNavigate, useSearchParams, useLocation } from 'react-router-dom'
 
 export default function WriteHeader() {
+  const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const location = useLocation()
+  const recruitmentId = searchParams.get('recruitmentId')
+  const isEditing = location.pathname.includes('/edit') || !!recruitmentId
+
   return (
     <div className="flex-between flex-col gap-8 md:flex-row">
       <div className="flex-center mr-auto gap-4">
         <Button
           variant="ghost"
           className="h-10 w-10 cursor-pointer rounded-full bg-gray-100 hover:bg-gray-200"
+          onClick={() => navigate(-1)}
         >
           <ArrowLeft className="h-6 w-6" />
         </Button>
         <div>
           <h2 className="text-3xl font-bold text-gray-900">
-            스터디 구인 공고 작성
+            {isEditing ? '스터디 구인 공고 수정' : '스터디 구인 공고 작성'}
           </h2>
           <p className="text-base text-gray-500">
-            스터디 그룹의 새로운 맴버를 모집하는 공고를 작성해보세요
+            {isEditing
+              ? '기존 공고를 수정하고 저장할 수 있습니다.'
+              : '스터디 그룹의 새로운 맴버를 모집하는 공고를 작성해보세요'}
           </p>
         </div>
       </div>

--- a/src/hooks/useWriteRecruitmentForm.ts
+++ b/src/hooks/useWriteRecruitmentForm.ts
@@ -115,7 +115,7 @@ export function useWriteRecruitmentForm() {
       file_name: file.name.replace(`.${ext}`, ''),
       file_ext: ext,
     })
-    // TODO: presigned.upload_url로 실제 파일을 PUT 업로드하도록 백엔드 연동 필요
+    await uploadToPresigned(presigned.upload_url, file, presigned.headers)
     return presigned.file_url
   }
 

--- a/src/hooks/useWriteRecruitmentForm.ts
+++ b/src/hooks/useWriteRecruitmentForm.ts
@@ -9,10 +9,16 @@ import { axiosInstance } from '@/api/axios'
 import type { UploadedFile } from '@/components/common/uploader/FileUploader'
 
 const formatCloseAt = (date: Date) => {
+  // 로컬 타임존 기준으로 00:00:00.000 시각을 ISO+오프셋 형태로 생성
   const yyyy = date.getFullYear()
   const mm = String(date.getMonth() + 1).padStart(2, '0')
   const dd = String(date.getDate()).padStart(2, '0')
-  return `${yyyy}-${mm}-${dd} 00:00:00`
+  const offsetMin = -new Date().getTimezoneOffset()
+  const sign = offsetMin >= 0 ? '+' : '-'
+  const pad = (n: number) => String(Math.abs(n)).padStart(2, '0')
+  const hhOffset = pad(Math.floor(Math.abs(offsetMin) / 60))
+  const mmOffset = pad(Math.abs(offsetMin) % 60)
+  return `${yyyy}-${mm}-${dd}T00:00:00.000${sign}${hhOffset}:${mmOffset}`
 }
 
 const RecruitmentPayloadSchema = z.object({
@@ -21,7 +27,7 @@ const RecruitmentPayloadSchema = z.object({
   content: z.string().min(1, '내용을 입력해주세요.'),
   expected_headcount: z.number().int().positive(),
   close_at: z.string().min(1),
-  estimated_fee: z.number().int().optional(),
+  estimated_fee: z.number().int().nonnegative(),
   tags: z.array(z.number().int()).optional(),
   image_urls: z.array(z.string().url()).max(5).optional(),
   files: z
@@ -41,7 +47,7 @@ export function useWriteRecruitmentForm() {
   const [title, setTitle] = useState('')
   const [estimatedFee, setEstimatedFee] = useState('')
   const [imageCount, setImageCount] = useState(0)
-  const [imageKeys, setImageKeys] = useState<string[]>([])
+  const [imageUrls, setImageUrls] = useState<string[]>([])
   const [tagIds, setTagIds] = useState<number[]>([])
   const [studyGroupId, setStudyGroupId] = useState<string>('')
   const [expectedHeadcount, setExpectedHeadcount] = useState<string>('')
@@ -104,7 +110,7 @@ export function useWriteRecruitmentForm() {
       file_ext: ext,
     })
     await uploadToPresigned(presigned.upload_url, file, presigned.headers)
-    setImageKeys((prev) => [...prev, presigned.key])
+    setImageUrls((prev) => [...prev, presigned.file_url])
     return presigned.file_url
   }
 
@@ -118,7 +124,7 @@ export function useWriteRecruitmentForm() {
       file_ext: ext,
     })
     await uploadToPresigned(presigned.upload_url, file, presigned.headers)
-    return presigned.file_url
+    return { previewUrl: presigned.file_url, key: presigned.key }
   }
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
@@ -129,7 +135,8 @@ export function useWriteRecruitmentForm() {
       !expectedHeadcount ||
       !deadline ||
       !title ||
-      !content
+      !content ||
+      estimatedFee === ''
     ) {
       showToast.warning('입력값 확인', '필수 항목을 모두 입력해주세요.')
       return
@@ -141,12 +148,12 @@ export function useWriteRecruitmentForm() {
       content,
       expected_headcount: Number(expectedHeadcount),
       close_at: formatCloseAt(deadline),
-      estimated_fee: estimatedFee ? Number(estimatedFee) : undefined,
+      estimated_fee: Number(estimatedFee),
       tags: tagIds.length ? tagIds : undefined,
-      image_urls: imageKeys,
+      image_urls: imageUrls,
       files: uploadedFiles.map((f) => ({
-        file_name: f.name,
-        file_url: f.url,
+        file_name: f.name, // 확장자 포함 원본 이름
+        file_url: f.url, // presigned 응답의 file_url(전체 URL)
       })),
     }
 
@@ -177,7 +184,7 @@ export function useWriteRecruitmentForm() {
     expectedHeadcount,
     uploadedFiles,
     tagIds,
-    imageKeys,
+    imageUrls,
   }
 
   const actions = {

--- a/src/hooks/useWriteRecruitmentForm.ts
+++ b/src/hooks/useWriteRecruitmentForm.ts
@@ -56,7 +56,6 @@ export function useWriteRecruitmentForm(
   const [expectedHeadcount, setExpectedHeadcount] = useState<string>('')
   const [uploadedFiles, setUploadedFiles] = useState<UploadedFile[]>([])
   const [totalLecturePrice, setTotalLecturePrice] = useState(0)
-  const [originalFileUrls, setOriginalFileUrls] = useState<string[]>([])
 
   const { data: studyGroups = [] } = useQuery({
     queryKey: ['study-groups'],
@@ -186,20 +185,11 @@ export function useWriteRecruitmentForm(
       estimated_fee: Number(estimatedFeeValue),
       tags: tagIds.length ? tagIds : undefined,
       image_urls: imageUrls,
-      // TODO: 백엔드와 첨부파일 수정 정책 협의 필요
-      //  - 덮어쓰기 방식인지(보낸 목록으로 교체), 삭제 API가 별도로 있는지 확인 후 로직 보완
-      //  - 현재는 기존 파일은 재전송하지 않고, 새로 추가된 파일만 전송
-      files: isEditing
-        ? uploadedFiles
-            .filter((f) => !originalFileUrls.includes(f.url)) // 기존 파일은 재전송하지 않음
-            .map((f) => ({
-              file_name: f.name,
-              file_url: f.url,
-            }))
-        : uploadedFiles.map((f) => ({
-            file_name: f.name, // 확장자 포함 원본 이름
-            file_url: f.url, // presigned 응답의 file_url(전체 URL)
-          })),
+      // TODO: 첨부파일 수정 정책(덮어쓰기 vs 개별 삭제)이 확정되면 로직 보완 필요
+      files: uploadedFiles.map((f) => ({
+        file_name: f.name, // 확장자 포함 원본 이름
+        file_url: f.url, // presigned 응답의 file_url(전체 URL)
+      })),
     }
 
     const parsed = RecruitmentPayloadSchema.safeParse(payload)
@@ -251,7 +241,6 @@ export function useWriteRecruitmentForm(
     setUploadedFiles,
     setTagIds,
     setImageUrls,
-    setOriginalFileUrls,
     onUploadImage,
     onUploadFile,
     handleSubmit,

--- a/src/hooks/useWriteRecruitmentForm.ts
+++ b/src/hooks/useWriteRecruitmentForm.ts
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router'
 import { useQuery } from '@tanstack/react-query'
 import { z } from 'zod'
@@ -40,7 +40,10 @@ const RecruitmentPayloadSchema = z.object({
     .optional(),
 })
 
-export function useWriteRecruitmentForm() {
+export function useWriteRecruitmentForm(
+  recruitmentId?: string,
+  isEditing = false
+) {
   const navigate = useNavigate()
   const [deadline, setDeadline] = useState<Date | undefined>()
   const [content, setContent] = useState('')
@@ -52,6 +55,8 @@ export function useWriteRecruitmentForm() {
   const [studyGroupId, setStudyGroupId] = useState<string>('')
   const [expectedHeadcount, setExpectedHeadcount] = useState<string>('')
   const [uploadedFiles, setUploadedFiles] = useState<UploadedFile[]>([])
+  const [totalLecturePrice, setTotalLecturePrice] = useState(0)
+  const [originalFileUrls, setOriginalFileUrls] = useState<string[]>([])
 
   const { data: studyGroups = [] } = useQuery({
     queryKey: ['study-groups'],
@@ -76,6 +81,29 @@ export function useWriteRecruitmentForm() {
   const remainingHeadcount = groupDetail
     ? Math.max(0, groupDetail.max_headcount - groupDetail.current_headcount)
     : 0
+
+  // 그룹 강의 비용 합계 계산
+  useEffect(() => {
+    if (!groupDetail?.lectures?.length) {
+      setTotalLecturePrice(0)
+      return
+    }
+    type LecturePrice = {
+      discounted_price?: number
+      discount_price?: number
+      original_price?: number
+    }
+    const sum = groupDetail.lectures.reduce((acc, lec) => {
+      const candidate = lec as LecturePrice
+      const price =
+        candidate.discounted_price ??
+        candidate.discount_price ??
+        candidate.original_price ??
+        0
+      return acc + price
+    }, 0)
+    setTotalLecturePrice(sum)
+  }, [groupDetail])
 
   const headcountOptions = useMemo(() => {
     if (remainingHeadcount <= 0) return []
@@ -130,13 +158,20 @@ export function useWriteRecruitmentForm() {
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
 
+    let estimatedFeeValue = estimatedFee
+    if (estimatedFeeValue === '') {
+      const fallback = totalLecturePrice > 0 ? totalLecturePrice : 0
+      estimatedFeeValue = String(fallback)
+      setEstimatedFee(estimatedFeeValue)
+    }
+
     if (
       !studyGroupId ||
       !expectedHeadcount ||
       !deadline ||
       !title ||
       !content ||
-      estimatedFee === ''
+      estimatedFeeValue === ''
     ) {
       showToast.warning('입력값 확인', '필수 항목을 모두 입력해주세요.')
       return
@@ -148,13 +183,23 @@ export function useWriteRecruitmentForm() {
       content,
       expected_headcount: Number(expectedHeadcount),
       close_at: formatCloseAt(deadline),
-      estimated_fee: Number(estimatedFee),
+      estimated_fee: Number(estimatedFeeValue),
       tags: tagIds.length ? tagIds : undefined,
       image_urls: imageUrls,
-      files: uploadedFiles.map((f) => ({
-        file_name: f.name, // 확장자 포함 원본 이름
-        file_url: f.url, // presigned 응답의 file_url(전체 URL)
-      })),
+      // TODO: 백엔드와 첨부파일 수정 정책 협의 필요
+      //  - 덮어쓰기 방식인지(보낸 목록으로 교체), 삭제 API가 별도로 있는지 확인 후 로직 보완
+      //  - 현재는 기존 파일은 재전송하지 않고, 새로 추가된 파일만 전송
+      files: isEditing
+        ? uploadedFiles
+            .filter((f) => !originalFileUrls.includes(f.url)) // 기존 파일은 재전송하지 않음
+            .map((f) => ({
+              file_name: f.name,
+              file_url: f.url,
+            }))
+        : uploadedFiles.map((f) => ({
+            file_name: f.name, // 확장자 포함 원본 이름
+            file_url: f.url, // presigned 응답의 file_url(전체 URL)
+          })),
     }
 
     const parsed = RecruitmentPayloadSchema.safeParse(payload)
@@ -166,8 +211,16 @@ export function useWriteRecruitmentForm() {
     }
 
     try {
-      await axiosInstance.post('/v1/recruitments', parsed.data)
-      showToast.success('공고 등록', '공고가 등록되었습니다.')
+      if (isEditing && recruitmentId) {
+        await axiosInstance.patch(
+          `/v1/recruitments/${recruitmentId}`,
+          parsed.data
+        )
+        showToast.success('공고 수정', '공고가 수정되었습니다.')
+      } else {
+        await axiosInstance.post('/v1/recruitments', parsed.data)
+        showToast.success('공고 등록', '공고가 등록되었습니다.')
+      }
       navigate('/manage')
     } catch (err) {
       showToast.error('공고 등록 실패', (err as Error)?.message ?? '')
@@ -197,6 +250,8 @@ export function useWriteRecruitmentForm() {
     setExpectedHeadcount,
     setUploadedFiles,
     setTagIds,
+    setImageUrls,
+    setOriginalFileUrls,
     onUploadImage,
     onUploadFile,
     handleSubmit,

--- a/src/hooks/useWriteRecruitmentForm.ts
+++ b/src/hooks/useWriteRecruitmentForm.ts
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router'
 import { useQuery } from '@tanstack/react-query'
 import { z } from 'zod'
 import { getStudyGroupDetail, getStudyGroups } from '@/api/studyGroup'
-import { getPresignedUrl } from '@/api/uploads'
+import { getPresignedUrl, uploadToPresigned } from '@/api/uploads'
 import { showToast } from '@/components/common/toast/Toast'
 import { axiosInstance } from '@/api/axios'
 import type { UploadedFile } from '@/components/common/uploader/FileUploader'
@@ -41,7 +41,7 @@ export function useWriteRecruitmentForm() {
   const [title, setTitle] = useState('')
   const [estimatedFee, setEstimatedFee] = useState('')
   const [imageCount, setImageCount] = useState(0)
-  const [imageUrls, setImageUrls] = useState<string[]>([])
+  const [imageKeys, setImageKeys] = useState<string[]>([])
   const [tagIds, setTagIds] = useState<number[]>([])
   const [studyGroupId, setStudyGroupId] = useState<string>('')
   const [expectedHeadcount, setExpectedHeadcount] = useState<string>('')
@@ -95,24 +95,26 @@ export function useWriteRecruitmentForm() {
   }
 
   const onUploadImage = async (file: File) => {
-    const ext = file.name.split('.').pop() ?? 'png'
+    const ext = (file.name.split('.').pop() ?? 'png').toLowerCase()
+    const contentType = file.type || 'application/octet-stream'
     const presigned = await getPresignedUrl({
       type: 'RECRUITMENT_IMAGE',
-      content_type: file.type,
-      file_name: file.name.replace(`.${ext}`, ''),
+      content_type: contentType,
+      file_name: file.name, // 확장자 포함 원본 이름 그대로 전송
       file_ext: ext,
     })
-    // TODO: presigned.upload_url로 실제 이미지를 PUT 전송한 뒤 성공 시 file_url을 사용하도록 연동 필요
-    setImageUrls((prev) => [...prev, presigned.file_url])
+    await uploadToPresigned(presigned.upload_url, file, presigned.headers)
+    setImageKeys((prev) => [...prev, presigned.key])
     return presigned.file_url
   }
 
   const onUploadFile = async (file: File) => {
-    const ext = file.name.split('.').pop() ?? 'dat'
+    const ext = (file.name.split('.').pop() ?? 'dat').toLowerCase()
+    const contentType = file.type || 'application/octet-stream'
     const presigned = await getPresignedUrl({
       type: 'RECRUITMENT_ATTACHMENT',
-      content_type: file.type || 'application/octet-stream',
-      file_name: file.name.replace(`.${ext}`, ''),
+      content_type: contentType,
+      file_name: file.name, // 확장자 포함 원본 이름 그대로 전송
       file_ext: ext,
     })
     await uploadToPresigned(presigned.upload_url, file, presigned.headers)
@@ -141,7 +143,7 @@ export function useWriteRecruitmentForm() {
       close_at: formatCloseAt(deadline),
       estimated_fee: estimatedFee ? Number(estimatedFee) : undefined,
       tags: tagIds.length ? tagIds : undefined,
-      image_urls: imageUrls,
+      image_urls: imageKeys,
       files: uploadedFiles.map((f) => ({
         file_name: f.name,
         file_url: f.url,
@@ -175,6 +177,7 @@ export function useWriteRecruitmentForm() {
     expectedHeadcount,
     uploadedFiles,
     tagIds,
+    imageKeys,
   }
 
   const actions = {

--- a/src/pages/postings/Manage.tsx
+++ b/src/pages/postings/Manage.tsx
@@ -7,8 +7,10 @@ import { useState, useEffect } from 'react'
 import type { MyRecruitmentParams } from '@/types/myRecruitment'
 import { useMyRecruitments } from '@/hooks/quries/useMyRecruitments'
 import { useInView } from 'react-intersection-observer'
+import { useNavigate } from 'react-router'
 
 export default function Manage() {
+  const navigate = useNavigate()
   const [status, setStatus] = useState<'all' | 'open' | 'closed'>('all')
   const [sort, setSort] = useState<MyRecruitmentParams['sort']>('latest')
 
@@ -43,7 +45,10 @@ export default function Manage() {
 
   return (
     <div className="mx-auto flex flex-col gap-6 px-4 py-6">
-      <ManageHeader />
+      <ManageHeader
+        onClickWrite={() => navigate('/write')}
+        onClickBack={() => navigate(-1)}
+      />
       <ManageDashboard
         totalCount={totalCount}
         openCount={openCount}


### PR DESCRIPTION
<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #125
- Resolves #127

## 📑 구현 사항

- 마크다운 presigned url api 에러 수정
- 첨부파일 presigned url api 에러 수정
- 공고 작성 api request body 상태 에러 수정
- 공고 수정시 첨부파일 스키마 수정
- 공고 수정 api request body 상태 에러 수정

## 🌀 어려웠던 점 / 고민했던 부분

- presigned api 사용시 놓쳤던 부분이 있는대 api 규격을 좀더 잘 보고 사용하게끔 기회가 됬습니다.
- 백엔드에서 에러 응답 내려줄때 네트워크 탭의 응답을 확인하고 어떤 부분이 문제인지 파악할수있는걸 학습했습니다.

## 📸 구현 이미지
<img width="1258" height="489" alt="image" src="https://github.com/user-attachments/assets/c0b0b739-dde0-4507-9896-9eb78bcb2efd" />
<img width="1249" height="576" alt="image" src="https://github.com/user-attachments/assets/9820fc65-3919-4ab9-8d4b-01d7eee8c71e" />
<img width="1191" height="279" alt="image" src="https://github.com/user-attachments/assets/cc7d36d2-d305-40b7-b924-ec444590d87d" />
<img width="1350" height="409" alt="image" src="https://github.com/user-attachments/assets/eb69ca9f-ad80-4501-b2ee-419b61420306" />


## ❇️ 코드 설명

1. 마크다운 이미지 presigned 업로드 수정
presigned 요청 시 파일명/확장자/Content-Type 정규화 → uploadToPresigned로 S3 PUT 후 image_urls에 file_url(URL) 전송.

2. 첨부파일 presigned 업로드 수정
presigned GET → PUT 업로드 적용, 미리보기는 file_url 사용, 최종 payload에 file_name+file_url(URL) 전송.

3. 공고 작성/수정 요청 포맷 수정
estimated_fee 필수 숫자, close_at ISO(+타임존) 형식, image_urls URL 배열로 전송.
작성/수정 모드 분기: 신규는 POST, 수정은 PATCH /v1/recruitments/{uuid}.

4. 공고 수정 시 첨부파일 처리
상세 응답으로 기존 파일 프리필, 수정 요청에서는 기존 file_url은 재전송하지 않고 새 파일만 전송(중복 에러 방지).
TODO: 백엔드와 삭제/덮어쓰기 정책 협의 필요.

5. 예상 비용/프리필 개선
스터디 그룹 변경 시 강의 합계(없으면 0)로 예상 비용 자동 입력, 입력 비었을 때도 합계로 채워서 전송.
상세 데이터 프리필: 스터디 그룹/이미지/첨부파일/예상 비용을 편집 화면에 반영.

## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1.
