### PR TITLE
fix: 사용자 맞춤 강의 추천 map 타입에러 오류 해결 및 기타  (#129)

### DIFF
--- a/src/api/lecture.ts
+++ b/src/api/lecture.ts
@@ -1,6 +1,7 @@
 import type {
   BookmarkResponse,
   LecturePageResponse,
+  LectureRecommendResponse,
   LecturesParams,
 } from '@/types/lecture'
 import { axiosInstance } from './axios'
@@ -26,13 +27,13 @@ export async function getLecturesApi(
 
 export async function getUserRecommendsLecturesApi(
   params: LecturesParams = {}
-): Promise<LecturePageResponse> {
+): Promise<LectureRecommendResponse> {
   // 객체타입 Record<키값:키밸류>
   const queryParams: Record<string, string | number> = {}
 
   if (params.max_count) queryParams.max_count = params.max_count
 
-  const { data } = await axiosInstance.get<LecturePageResponse>(
+  const { data } = await axiosInstance.get<LectureRecommendResponse>(
     '/v1/lectures/recommends',
     { params: queryParams }
   )
@@ -45,16 +46,16 @@ export async function getBookmark(): Promise<BookmarkResponse> {
   return data
 }
 
-export async function addBookmark(lectureId: number): Promise<string> {
+export async function addBookmark(lecture: number): Promise<string> {
   const { data } = await axiosInstance.post('/v1/lecture-bookmarks', {
-    lecture_id: lectureId,
+    lecture,
   })
   return data.detail
 }
 
-export async function deleteBookmark(lectureId: number): Promise<string> {
+export async function deleteBookmark(lecture_id: number): Promise<string> {
   const { data } = await axiosInstance.delete(
-    `/v1/lecture-bookmarks/${lectureId}`
+    `/v1/lecture-bookmarks/${lecture_id}`
   )
   return data.detail
 }

--- a/src/components/GuestRecommendSection.tsx
+++ b/src/components/GuestRecommendSection.tsx
@@ -1,3 +1,4 @@
+import { ROUTE_PATHS } from '@/constant/route'
 import { LogIn, UserPlus } from 'lucide-react'
 import { useNavigate } from 'react-router'
 import { Button } from './common/Button'
@@ -21,13 +22,16 @@ export default function GuestRecommendSection({
           {description}를 추천해드립니다.
         </p>
         <div className="mt-6 flex items-center justify-center gap-x-4">
-          <Button variant={'primary'} onClick={() => navigate('/login')}>
+          <Button
+            variant={'primary'}
+            onClick={() => navigate(ROUTE_PATHS.LOGIN)}
+          >
             <LogIn />
             로그인하기
           </Button>
           <Button
             variant={'outline-primary'}
-            onClick={() => navigate('/signup')}
+            onClick={() => navigate(ROUTE_PATHS.SIGNUP)}
           >
             <UserPlus />
             회원가입 하기

--- a/src/components/common/GuestRecommendSection.tsx
+++ b/src/components/common/GuestRecommendSection.tsx
@@ -1,3 +1,4 @@
+import { ROUTE_PATHS } from '@/constant/route'
 import { LogIn, UserPlus } from 'lucide-react'
 import { useNavigate } from 'react-router'
 import { Button } from './Button'
@@ -21,13 +22,16 @@ export default function GuestRecommendSection({
           {description}를 추천해드립니다.
         </p>
         <div className="mt-6 flex items-center justify-center gap-2">
-          <Button variant={'primary'} onClick={() => navigate('/login')}>
+          <Button
+            variant={'primary'}
+            onClick={() => navigate(ROUTE_PATHS.LOGIN)}
+          >
             <LogIn />
             로그인하기
           </Button>
           <Button
             variant={'outline-primary'}
-            onClick={() => navigate('/signup')}
+            onClick={() => navigate(ROUTE_PATHS.SIGNUP)}
           >
             <UserPlus />
             회원가입 하기

--- a/src/components/common/header/MobileModal.tsx
+++ b/src/components/common/header/MobileModal.tsx
@@ -12,7 +12,7 @@ interface MobileModalProps {
   setIsModalOpen: (value: boolean) => void
 }
 function MobileModal({ setIsModalOpen }: MobileModalProps) {
-  const { user, loginState } = useAuthStore()
+  const { user, loginState, clearAuth } = useAuthStore()
   return (
     <div className="bg-basic-white fixed top-0 left-0 z-10 h-screen w-[263px] pt-4 md:hidden">
       <div className="border-b border-solid border-gray-200">
@@ -74,7 +74,10 @@ function MobileModal({ setIsModalOpen }: MobileModalProps) {
           </button>
           <button className="flex cursor-pointer items-center justify-center gap-[13px] rounded-lg bg-gray-100 px-4 py-2">
             <img src={logoutIcon} alt="logoutIcon" />
-            <span className="text-base font-medium text-gray-700">
+            <span
+              className="text-base font-medium text-gray-700"
+              onClick={() => clearAuth()}
+            >
               로그아웃
             </span>
           </button>

--- a/src/components/common/header/User.tsx
+++ b/src/components/common/header/User.tsx
@@ -92,7 +92,7 @@ function User() {
       >
         <div className="flex h-8 w-8 items-center justify-center overflow-hidden rounded-full bg-[#FEF9C3]">
           <img
-            src={user?.profile_img_url ? user?.profile_img_url : defaultImg}
+            src={user?.profile_img_url ? user.profile_img_url : defaultImg}
             alt="profileIcon"
             className="h-full w-full object-cover"
           />

--- a/src/components/common/header/UserModal.tsx
+++ b/src/components/common/header/UserModal.tsx
@@ -1,12 +1,14 @@
 import logoutIcon from '@/assets/icons/logout.svg'
 import modalProfileIcon from '@/assets/icons/modalProfileIcon.svg'
 import { ROUTE_PATHS } from '@/constant/route'
+import { useAuthStore } from '@/store/userStore'
 function UserModal() {
+  const { clearAuth } = useAuthStore()
   return (
     <div className="md:bg-basic-white hidden md:absolute md:top-[45.05px] md:right-2.5 md:flex md:h-[99px] md:w-48 md:flex-col md:gap-2 md:rounded-lg md:border md:border-solid md:border-[#E5E7EB] md:drop-shadow-[0_10px_15px_rgba(0,0,0,0.2)]">
       <div className="mt-[13px] flex cursor-pointer items-center gap-3 border-t-2 border-solid border-gray-100 px-4 py-2.5 pt-[5px] text-[16px] text-gray-700">
         <img src={logoutIcon} alt="logoutIcon" className="h-[18px] w-[18px]" />
-        <span>로그아웃</span>
+        <span onClick={() => clearAuth()}>로그아웃</span>
         {/* 클릭하면 로그아웃 시키기 */}
       </div>
       <div className="flex cursor-pointer items-center gap-3 px-4 py-2.5 text-[16px] text-gray-700">

--- a/src/components/lecture/LectureRecommendSection.tsx
+++ b/src/components/lecture/LectureRecommendSection.tsx
@@ -18,7 +18,7 @@ export default function LectureRecommendSection() {
         </div>
 
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {data?.results.map((i) => (
+          {data?.map((i) => (
             <LectureCard key={i.id} {...i}></LectureCard>
           ))}
         </div>

--- a/src/components/postings/recruitment/PublicBanner.tsx
+++ b/src/components/postings/recruitment/PublicBanner.tsx
@@ -1,5 +1,5 @@
-import { Bell, LogIn, UserPlus } from 'lucide-react'
 import CardSkeleton from '@/components/common/CardSkeleton'
+import { Bell, LogIn, UserPlus } from 'lucide-react'
 
 export default function PublicBanner() {
   return (

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -5,7 +5,7 @@ const useDebounce = <T>(value: T, delay: number = 500): T => {
   const [debouncedValue, setDebouncedValue] = useState<T>(value)
 
   useEffect(() => {
-    const timer = setTimeout(() => setDebouncedValue(value), delay || 2000)
+    const timer = setTimeout(() => setDebouncedValue(value), delay)
 
     return () => {
       clearTimeout(timer)

--- a/src/pages/CoursesPage.tsx
+++ b/src/pages/CoursesPage.tsx
@@ -67,7 +67,7 @@ export default function Courses() {
           <GuestRecommendSection
             title="강의를"
             description="로그인하시면 관심 분야를 바탕으로 맞춤형 강의"
-          ></GuestRecommendSection>
+          />
         )}
       </section>
       <section className="courses_filter flex flex-col items-center gap-2 rounded-md border border-gray-200 bg-white p-6 sm:flex-row">
@@ -76,7 +76,7 @@ export default function Courses() {
           className="h-[38px]"
           value={inputValue}
           onChange={(e) => setInputValue(e.target.value)}
-        ></Input>
+        />
         <Select
           icon={<Folder />}
           name="category"
@@ -90,7 +90,7 @@ export default function Courses() {
                 : (value as LecturesParams['category'])
             )
           }}
-        ></Select>
+        />
         <Select
           name="sort"
           icon={<ArrowDownWideNarrow />}
@@ -104,17 +104,17 @@ export default function Courses() {
                 : (value as LecturesParams['sort'])
             )
           }}
-        ></Select>
+        />
       </section>
       {isLoading ? (
-        <Loading></Loading>
+        <Loading />
       ) : (
         <section className="courses_cardlist">
           {/* 검색결과 없으면 NoSearchResult */}
           {hasNoResult ? (
             <NoSearchResult searchResult={debouncedInputValue} />
           ) : (
-            <LectureList data={data}></LectureList>
+            <LectureList data={data} />
           )}
         </section>
       )}
@@ -123,7 +123,7 @@ export default function Courses() {
           더 이상 강의가 없습니다.
         </div>
       )}
-      {!hasNoResult && hasNextPage && <div ref={ref}></div>}
+      {!hasNoResult && hasNextPage && <div ref={ref} />}
     </div>
   )
 }

--- a/src/types/lecture.ts
+++ b/src/types/lecture.ts
@@ -33,6 +33,7 @@ export type LecturePageResponse = {
   previous: string | null
   results: Lecture[]
 }
+export type LectureRecommendResponse = Lecture[]
 
 export type BookmarkResponse = {
   next: string | null


### PR DESCRIPTION
<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #129

## 📑 구현 사항

- 사용자 맞춤 강의 추천 API의 응답 타입 불일치 문제 해결
- 북마크 API 파라미터를 백엔드 스펙에 맞게 수정
- 로그아웃 기능 구현 및 라우팅 경로 상수화


## 🌀 어려웠던 점 / 고민했던 부분
### 추천강의 로직 
- 추천 강의 코드 확인 시 , 응답 구조가 잘못되었다는 걸 깨달음
- 추천 강의 코드와, 전체 강의 코드 응답 구조를 재탕하고 있었음 
- 그래서 추천 강의 응답 코드를 다시 확인하였고, 그거에 맞추어 api응답 타입 구조 수정하였다. 
<img width="2672" height="1522" alt="스크린샷 2025-12-24 오후 1 19 26" src="https://github.com/user-attachments/assets/8fa2f29a-1c6c-469f-b4f1-7f0bfcaaf71c" />
- 응답구조는 위와 같이 배열내의 강의 목록만 뱉어내고 있었음 

### 해결완
<img width="1464" height="960" alt="스크린샷 2025-12-24 오후 1 59 28" src="https://github.com/user-attachments/assets/82913363-9fbc-44ed-b7cf-b76181485b41" />


## 📸 구현 이미지
### 화면 랜더링
![추천강의랜더링](https://github.com/user-attachments/assets/d5fc77fc-da13-4306-bd03-6187a5715b1d)



### 북마크
![북마크](https://github.com/user-attachments/assets/3ef51361-81ce-4889-b5e7-49057fa5b45f)



### 로그아웃 로그인
![로그인아웃](https://github.com/user-attachments/assets/55de8377-9329-4886-87dd-f3fe74ea0fc1)





## ❇️ 코드 설명
### 추천강의 API 타입 수정
```tsx
//타입수정
export type LectureRecommendResponse = Lecture[]

 {data?.map((i) => (
            <LectureCard key={i.id} {...i}></LectureCard>
          ))}
```

- getUserRecommendsLecturesApi 응답 타입을 LecturePageResponse에서 LectureRecommendResponse로 변경
- 백엔드에서 페이지네이션 객체가 아닌 배열을 직접 반환하는 스펙에 맞춰 타입 정의 추가
- LectureRecommendSection 컴포넌트에서 data.results → data로 접근 방식 수정

### 북마크 API 파라미터 통일 ( 서버 연결 수정사항)

- addBookmark: 파라미터명 lectureId → lecture, 요청 바디 lecture_id → lecture
- deleteBookmark: 파라미터명 lectureId → lecture_id ( 포스트맨 확인했음)

### 로그아웃 기능 구현

- UserModal (Desktop)에서 로그아웃 클릭 시 clearAuth() 호출
- MobileModal에서 로그아웃 클릭 시 clearAuth() 호출


## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1. 추천 강의 불러오기 잘 실행이 되었지만, 불러오기까지 시간이 느리게 걸리는 듯 합니다.... 이 부분 최적화 시켜보도록 하겠습니다.
