### PR TITLE
fix: 타입 정의 개선 및 useQuery에서 데이터 처리 방식 수정(#135)

### DIFF
--- a/src/components/postings/detail/DetailHeader.tsx
+++ b/src/components/postings/detail/DetailHeader.tsx
@@ -1,13 +1,5 @@
 import type { Recruitment } from '@/types/recruitment'
-import {
-  ArrowLeft,
-  Share2,
-  Bookmark,
-  Edit,
-  User,
-  Calendar,
-  Eye,
-} from 'lucide-react'
+import { ArrowLeft, Share2, Bookmark, User, Calendar, Eye } from 'lucide-react'
 import { Button } from '@/components/common/Button'
 import { showToast } from '@/components/common/toast/Toast'
 import { useState } from 'react'

--- a/src/components/postings/write/WriteForm.tsx
+++ b/src/components/postings/write/WriteForm.tsx
@@ -346,24 +346,25 @@ export default function WriteForm() {
     enabled: lecturesFromGroup.length > 0,
   })
 
-  const { data: detail } = useQuery<
-    | {
-        title: string
-        content: string
-        estimated_fee?: number
-        expected_headcount: number
-        close_at: string
-        tags: { id: number; name: string }[]
-        image_urls?: string[]
-        study_group?: number
-        files?: { file_name: string; file_url: string }[]
-      }
-    | undefined
-  >({
+  type WriteRecruitmentDetail = {
+    title: string
+    content: string
+    estimated_fee?: number
+    expected_headcount: number
+    close_at: string
+    tags: { id: number; name: string }[]
+    image_urls?: string | string[]
+    study_group?: number
+    files?: { file_name: string; file_url: string }[]
+  }
+
+  const { data: detail } = useQuery<WriteRecruitmentDetail | undefined>({
     queryKey: ['my-recruitment-detail', recruitmentId],
     queryFn: async () => {
       if (!recruitmentId) return undefined
-      const res = await getRecruitmentDetail(recruitmentId)
+      const res = (await getRecruitmentDetail(
+        recruitmentId
+      )) as unknown as WriteRecruitmentDetail
       // 디버깅용: 상세 데이터 확인
       // eslint-disable-next-line no-console
       console.log('Recruitment detail', res)
@@ -417,24 +418,26 @@ export default function WriteForm() {
       actions.setStudyGroupId(String(detail.study_group))
     }
     if (detail.files?.length) {
-      const presetFiles = detail.files.map((f, idx) => {
-        const lowerName = f.file_name.toLowerCase()
-        const lowerUrl = f.file_url.toLowerCase()
-        const isImage =
-          /\.(png|jpe?g|webp)$/.test(lowerName) ||
-          /\.(png|jpe?g|webp)$/.test(lowerUrl)
-        const isPdf = lowerName.endsWith('.pdf') || lowerUrl.endsWith('.pdf')
-        let type = 'application/octet-stream'
-        if (isImage) type = 'image/'
-        else if (isPdf) type = 'application/pdf'
-        return {
-          id: `${f.file_name}-${idx}`,
-          name: f.file_name,
-          size: 0,
-          type,
-          url: f.file_url,
+      const presetFiles = detail.files.map(
+        (f: { file_name: string; file_url: string }, idx: number) => {
+          const lowerName = f.file_name.toLowerCase()
+          const lowerUrl = f.file_url.toLowerCase()
+          const isImage =
+            /\.(png|jpe?g|webp)$/.test(lowerName) ||
+            /\.(png|jpe?g|webp)$/.test(lowerUrl)
+          const isPdf = lowerName.endsWith('.pdf') || lowerUrl.endsWith('.pdf')
+          let type = 'application/octet-stream'
+          if (isImage) type = 'image/'
+          else if (isPdf) type = 'application/pdf'
+          return {
+            id: `${f.file_name}-${idx}`,
+            name: f.file_name,
+            size: 0,
+            type,
+            url: f.file_url,
+          }
         }
-      })
+      )
       actions.setUploadedFiles(presetFiles)
     }
     if (detail.image_urls) {
@@ -443,9 +446,12 @@ export default function WriteForm() {
         : [detail.image_urls]
       actions.setImageUrls(urls.filter(Boolean))
     }
-    setTagIds(detail.tags?.map((t) => t.id) ?? [])
+    setTagIds(detail.tags?.map((t: { id: number }) => t.id) ?? [])
     setSelectedTags(
-      detail.tags?.map((t) => ({ id: String(t.id), name: t.name })) ?? []
+      detail.tags?.map((t: { id: number; name: string }) => ({
+        id: String(t.id),
+        name: t.name,
+      })) ?? []
     )
     if (detail.close_at) {
       handleDeadlineChange(new Date(detail.close_at))


### PR DESCRIPTION
- 빌드시 터지는 타입 에러 수정

<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #135

## 📑 구현 사항

- 빌드 에러 수정

## 🌀 어려웠던 점 / 고민했던 부분

-

## 📸 구현 이미지

-

## ❇️ 코드 설명

- 작성/수정 폼 타입 정리
WriteForm의 상세 조회 타입을 명시(WriteRecruitmentDetail)하고, tags/files/image_urls 등에 타입을 지정했습니다. React Query가 기대하는 타입과 응답을 맞춰 빌드 에러를 해소했습니다.
상세 응답 캐스팅을 unknown as WriteRecruitmentDetail로 안전하게 처리했습니다.

- 기타 빌드 오류 정리
DetailHeader에서 사용하지 않는 Edit 아이콘 import 제거.

## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1.
