### PR TITLE
Fix: 알림 카운트 오류 개선 및 스트리밍 훅 분리 (#132)

### DIFF
--- a/src/hooks/quries/useCursorInfiniteQuery.ts
+++ b/src/hooks/quries/useCursorInfiniteQuery.ts
@@ -4,6 +4,8 @@ type CursorPage<T> = {
   next: string | null
   previous: string | null
   results: T[]
+  total?: number
+  unread_total?: number
 }
 
 type UseCursorInfiniteQueryParams<T> = {

--- a/src/hooks/quries/useNotifications.ts
+++ b/src/hooks/quries/useNotifications.ts
@@ -7,40 +7,12 @@ import {
 } from '@/mappers/notification/mapper'
 import type { AlarmItem } from '@/types/alarm'
 import { useCursorInfiniteQuery } from './useCursorInfiniteQuery'
-import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useQueryClient } from '@tanstack/react-query'
 
 type FilterKey = 'all' | 'unread' | 'read'
 
 // 커서 기반 알림 조회 훅
 export const useNotifications = (filter: FilterKey) => {
-  // 총합/미읽음 카운트용 쿼리
-  const totalCountQuery = useQuery<number>({
-    queryKey: ['notifications-total-count'],
-    queryFn: async () => {
-      const { data } = await axiosInstance.get<NotificationListResponse>(
-        '/v1/notifications',
-        { params: { page_size: 1 } }
-      )
-      return data.total_count ?? data.results.length
-    },
-    staleTime: 1000 * 60,
-  })
-
-  const unreadCountQuery = useQuery<number>({
-    queryKey: ['notifications-unread-count'],
-    queryFn: async () => {
-      const { data } = await axiosInstance.get<NotificationListResponse>(
-        '/v1/notifications',
-        { params: { page_size: 1, is_read: false } }
-      )
-      // 백엔드가 unread_count를 내려주면 활용, 없으면 total_count 대체
-      const unread =
-        data.unread_count ?? data.total_count ?? data.results.length
-      return unread
-    },
-    staleTime: 1000 * 60,
-  })
-
   const query = useCursorInfiniteQuery<AlarmItem>({
     queryKey: ['notifications', filter],
     queryFn: async (cursorUrl) => {
@@ -59,10 +31,19 @@ export const useNotifications = (filter: FilterKey) => {
                 },
               }
             )
+        const mapped = data.results.map((item) =>
+          alarmMapper({
+            ...item,
+            // 서버가 is_read를 잘못 내려줄 때를 대비해 필터에 따라 보정
+            is_read: filter === 'unread' ? false : item.is_read,
+          })
+        )
         return {
           next: data.next,
           previous: data.previous,
-          results: data.results.map(alarmMapper),
+          total: data.total,
+          unread_total: (data as any).unread_total,
+          results: mapped,
         }
       } catch (err) {
         if (isAxiosError(err)) {
@@ -79,8 +60,9 @@ export const useNotifications = (filter: FilterKey) => {
   const alarms = query.data?.pages.flatMap((p) => p.results ?? []) ?? []
   const errorMessage = query.error ? query.error.message : null
 
-  const totalCount = totalCountQuery.data ?? 0
-  const unreadCount = unreadCountQuery.data ?? 0
+  const meta = query.data?.pages?.[0]
+  const totalCount = meta?.total ?? alarms.length
+  const unreadCount = meta?.unread_total ?? 0
   const readCount = Math.max(0, totalCount - unreadCount)
 
   return {
@@ -101,8 +83,6 @@ export const useNotificationActions = () => {
   const queryClient = useQueryClient()
 
   const invalidateNotificationCaches = () => {
-    queryClient.invalidateQueries({ queryKey: ['notifications-total-count'] })
-    queryClient.invalidateQueries({ queryKey: ['notifications-unread-count'] })
     queryClient.invalidateQueries({ queryKey: ['notifications'] })
   }
 

--- a/src/hooks/useNotificationStream.ts
+++ b/src/hooks/useNotificationStream.ts
@@ -36,8 +36,18 @@ export function useNotificationStream(options?: UseNotificationStreamOptions) {
 
     es.onmessage = (event: MessageEvent) => {
       try {
-        const raw = JSON.parse(event.data) as NotificationApiItem
+        const raw = JSON.parse(event.data) as NotificationApiItem & {
+          type?: string
+          id?: number | string
+        }
+        // keepalive/connected 이벤트는 무시
+        if (!raw.id || raw.type === 'connected') {
+          return
+        }
         const alarm = alarmMapper(raw)
+        // 새 알림 로그로 식별 가능하게 기록
+        // eslint-disable-next-line no-console
+        console.log('[SSE] new notification', raw)
         // 새 알림을 캐시에 바로 반영해 추가 페칭을 줄입니다.
         const filters: Array<'all' | 'unread' | 'read'> = [
           'all',
@@ -51,6 +61,8 @@ export function useNotificationStream(options?: UseNotificationStreamOptions) {
             next: string | null
             previous: string | null
             results: ReturnType<typeof alarmMapper>[]
+            total?: number
+            unread_total?: number
           }
           queryClient.setQueryData<InfiniteData<CursorPage>>(
             ['notifications', filterKey],
@@ -62,8 +74,16 @@ export function useNotificationStream(options?: UseNotificationStreamOptions) {
               )
               if (exists) return prev
               const [firstPage, ...rest] = prev.pages
+              const isUnread = !alarm.isRead
+              const nextTotal = (firstPage.total ?? 0) + 1
+              const nextUnread =
+                filterKey !== 'read' && isUnread
+                  ? (firstPage.unread_total ?? 0) + 1
+                  : firstPage.unread_total
               const updatedFirstPage = {
                 ...firstPage,
+                total: nextTotal,
+                unread_total: nextUnread,
                 results: [alarm, ...firstPage.results],
               }
               return {
@@ -72,13 +92,6 @@ export function useNotificationStream(options?: UseNotificationStreamOptions) {
               }
             }
           )
-        })
-        // 카운트 쿼리도 무효화하여 상단 카운트 반영
-        queryClient.invalidateQueries({
-          queryKey: ['notifications-total-count'],
-        })
-        queryClient.invalidateQueries({
-          queryKey: ['notifications-unread-count'],
         })
         optionsRef.current?.onMessage?.(alarm)
       } catch (e) {

--- a/src/hooks/useNotificationStream.ts
+++ b/src/hooks/useNotificationStream.ts
@@ -8,6 +8,10 @@ import {
 } from '@/mappers/notification/mapper'
 import { useAuthStore } from '@/store/userStore'
 
+type StreamMessage =
+  | (NotificationApiItem & { id: number | string })
+  | { type: 'connected'; id?: undefined }
+
 type UseNotificationStreamOptions = {
   onMessage?: (data: ReturnType<typeof alarmMapper>) => void
   onUnauthorized?: () => void
@@ -36,12 +40,10 @@ export function useNotificationStream(options?: UseNotificationStreamOptions) {
 
     es.onmessage = (event: MessageEvent) => {
       try {
-        const raw = JSON.parse(event.data) as NotificationApiItem & {
-          type?: string
-          id?: number | string
-        }
+        const raw = JSON.parse(event.data) as StreamMessage
+        const msgType = (raw as StreamMessage)['type']
         // keepalive/connected 이벤트는 무시
-        if (!raw.id || raw.type === 'connected') {
+        if (!raw.id || msgType === 'connected') {
           return
         }
         const alarm = alarmMapper(raw)

--- a/src/mappers/notification/mapper.ts
+++ b/src/mappers/notification/mapper.ts
@@ -22,13 +22,14 @@ export type NotificationListResponse = {
   results: NotificationApiItem[]
   next: string | null
   previous: string | null
-  total_count?: number
-  unread_count?: number
+  total?: number
+  unread_total?: number
 }
 
 // ISO 날짜 문자열을 "12월 1일" 형태로 포맷
 const formatDate = (isoString: string) => {
   const date = new Date(isoString)
+  if (Number.isNaN(date.getTime())) return ''
   const month = date.getMonth() + 1
   const day = date.getDate()
   return `${month}월 ${day}일`
@@ -63,12 +64,12 @@ export const alarmMapper = (item: NotificationApiItem): AlarmItem => {
   const iconType = typeToIcon[item.type as keyof typeof typeToIcon] ?? 'apply'
 
   return {
-    id: String(item.id),
-    message: item.content,
-    date: formatDate(item.created_at),
-    isRead: item.is_read,
+    id: String(item.id ?? crypto.randomUUID()),
+    message: item.content ?? '',
+    date: formatDate(item.created_at ?? ''),
+    isRead: !!item.is_read,
     accent,
     iconType,
-    backUrl: item.back_url_link,
+    backUrl: item.back_url_link ?? '',
   }
 }


### PR DESCRIPTION
<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #132

## 📑 구현 사항

- 알림 목록/카운트를 /v1/notifications 응답의 total/unread_total로 일원화하고, SSE로 들어온 새 알림을 캐시에 바로 prepend.
- SSE keepalive(type: "connected")는 무시하고, 중복 ID도 추가하지 않도록 가드.
- 알림 매퍼에서 잘못된 날짜/빈 값이 와도 안전하게 매핑해 NaN NaN 등 깨진 알림을 방지.

## 🌀 어려웠던 점 / 고민했던 부분

- 기존엔 카운트를 따로 쿼리해서 불필요한 API 호출이 많았고, SSE 메시지까지 알림으로 붙어 중복/깨진 항목이 생김.
- Maximum update depth를 유발하지 않으면서 스터디 그룹/예상비용 자동 세팅을 어떻게 한 번만 실행할지 고민했고, 플래그와 값 비교 가드로 해결.

## 📸 구현 이미지

https://github.com/user-attachments/assets/7847a490-19d3-4113-8c51-cd066fe1402c



## ❇️ 코드 설명

### 알림 REST + SSE 결합
```tsx
// useNotifications: REST로 초기/추가 페이지 가져오며 total/unread_total 보관
const query = useCursorInfiniteQuery<AlarmItem>({
  queryKey: ['notifications', filter],
  queryFn: async (cursorUrl) => {
    const { data } = cursorUrl
      ? await axiosInstance.get<NotificationListResponse>(cursorUrl)
      : await axiosInstance.get<NotificationListResponse>('/v1/notifications', { params: { page_size: 10, ... } })
    return {
      next: data.next,
      previous: data.previous,
      total: data.total,
      unread_total: (data as any).unread_total,
      results: data.results.map(alarmMapper),
    }
  },
})
const meta = query.data?.pages?.[0]
const totalCount = meta?.total ?? alarms.length
const unreadCount = meta?.unread_total ?? 0
```
```tsx
// useNotificationStream: SSE 새 알림 prepend + 카운트 증가, keepalive 무시
type StreamMessage = NotificationApiItem | { type: 'connected'; id?: undefined }
if (!raw.id || msgType === 'connected') return
queryClient.setQueryData(['notifications', filterKey], (prev) => {
  if (!prev || exists) return prev
  const updatedFirstPage = {
    ...firstPage,
    total: (firstPage.total ?? 0) + 1,
    unread_total: filterKey !== 'read' && !alarm.isRead
      ? (firstPage.unread_total ?? 0) + 1
      : firstPage.unread_total,
    results: [alarm, ...firstPage.results],
  }
  return { ...prev, pages: [updatedFirstPage, ...rest] }
})
```
### 알림 매퍼 가드
```tsx
const formatDate = (iso: string) => {
  const d = new Date(iso)
  if (Number.isNaN(d.getTime())) return ''
  return `${d.getMonth() + 1}월 ${d.getDate()}일`
}
const alarmMapper = (item) => ({
  id: String(item.id ?? crypto.randomUUID()),
  message: item.content ?? '',
  date: formatDate(item.created_at ?? ''),
  isRead: !!item.is_read,
  backUrl: item.back_url_link ?? '',
  ...
})
```
### 폼 자동 세팅 루프 방지 (요약)
```tsx
// 값이 같으면 setState 생략, 스터디 그룹은 옵션 준비 후 한 번만 세팅
if (state.estimatedFee !== String(fallback)) setEstimatedFee(String(fallback))
if (!groupPrefilled && detail.study_group && options.groupOptions.length) {
  setStudyGroupId(String(detail.study_group))
  setGroupPrefilled(true)
}
```

## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1.
