### PR TITLE
refactor: 알림 카운트 로직 개선(#141)

### DIFF
--- a/src/hooks/quries/useCursorInfiniteQuery.ts
+++ b/src/hooks/quries/useCursorInfiniteQuery.ts
@@ -1,4 +1,8 @@
-import { useInfiniteQuery, type QueryKey } from '@tanstack/react-query'
+import {
+  keepPreviousData,
+  useInfiniteQuery,
+  type QueryKey,
+} from '@tanstack/react-query'
 
 type CursorPage<T> = {
   next: string | null
@@ -26,5 +30,6 @@ export function useCursorInfiniteQuery<T>({
     initialPageParam: undefined,
     getNextPageParam: (lastPage) => lastPage.next ?? undefined,
     enabled,
+    placeholderData: keepPreviousData,
   })
 }

--- a/src/hooks/quries/useNotifications.ts
+++ b/src/hooks/quries/useNotifications.ts
@@ -8,6 +8,7 @@ import {
 import type { AlarmItem } from '@/types/alarm'
 import { useCursorInfiniteQuery } from './useCursorInfiniteQuery'
 import { useQueryClient } from '@tanstack/react-query'
+import { useEffect, useState } from 'react'
 
 type FilterKey = 'all' | 'unread' | 'read'
 
@@ -60,9 +61,21 @@ export const useNotifications = (filter: FilterKey) => {
   const alarms = query.data?.pages.flatMap((p) => p.results ?? []) ?? []
   const errorMessage = query.error ? query.error.message : null
 
-  const meta = query.data?.pages?.[0]
-  const totalCount = meta?.total ?? alarms.length
-  const unreadCount = meta?.unread_total ?? 0
+  // 카운트 깜빡임 방지를 위해 상태에 보관 후 값이 달라질 때만 업데이트
+  const [counts, setCounts] = useState({ total: 0, unread: 0 })
+  useEffect(() => {
+    const meta = query.data?.pages?.[0]
+    if (!meta) return
+    const nextTotal = meta.total ?? alarms.length
+    const nextUnread = meta.unread_total ?? counts.unread
+    if (nextTotal !== counts.total || nextUnread !== counts.unread) {
+      setCounts({ total: nextTotal, unread: nextUnread })
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [query.data?.pages, alarms.length])
+
+  const totalCount = counts.total
+  const unreadCount = counts.unread
   const readCount = Math.max(0, totalCount - unreadCount)
 
   return {


### PR DESCRIPTION


<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #141

## 📑 구현 사항

- 카운트 유지 로직 구현

## 🌀 어려웠던 점 / 고민했던 부분

-

## 📸 구현 이미지

- 

## ❇️ 코드 설명

```tsx
// 카운트 깜빡임 방지를 위해 상태에 보관 후 값이 달라질 때만 업데이트
  const [counts, setCounts] = useState({ total: 0, unread: 0 })
  useEffect(() => {
    const meta = query.data?.pages?.[0]
    if (!meta) return
    const nextTotal = meta.total ?? alarms.length
    const nextUnread = meta.unread_total ?? counts.unread
    if (nextTotal !== counts.total || nextUnread !== counts.unread) {
      setCounts({ total: nextTotal, unread: nextUnread })
    }
    // eslint-disable-next-line react-hooks/exhaustive-deps
  }, [query.data?.pages, alarms.length])

  const totalCount = counts.total
  const unreadCount = counts.unread
```
total 값을 상태로 저장하여 노출시키고
알림 목록 fetch 시 값이달라질때만 업데이트

## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1.
