### PR TITLE
Feat: 지원자 관리/알림 연동 개선(#140)

### DIFF
--- a/src/api/applications.ts
+++ b/src/api/applications.ts
@@ -1,0 +1,9 @@
+import { axiosInstance } from './axios'
+
+export const approveApplication = async (applicationId: number | string) => {
+  await axiosInstance.post(`/v1/applications/${applicationId}/accept`)
+}
+
+export const rejectApplication = async (applicationId: number | string) => {
+  await axiosInstance.post(`/v1/applications/${applicationId}/reject`)
+}

--- a/src/components/common/notification/NotificationModal.tsx
+++ b/src/components/common/notification/NotificationModal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { motion, useAnimation } from 'framer-motion'
+import { useNavigate } from 'react-router-dom'
 
 import {
   useNotificationActions,
@@ -24,6 +25,7 @@ export default function NotificationModal({
   onClose,
   onAnimationComplete,
 }: NotificationModalProps) {
+  const navigate = useNavigate()
   const SCROLL_THRESHOLD = 80
   const [activeFilter, setActiveFilter] = useState<'all' | 'unread' | 'read'>(
     'all'
@@ -98,13 +100,18 @@ export default function NotificationModal({
           return
         }
 
+        const urlObj = new URL(alarm.backUrl, window.location.origin)
         const backendHost = new URL(API_BASE_URL).host
-        const targetHost = new URL(alarm.backUrl).host
-        const shouldNewTab = backendHost !== targetHost
-        if (shouldNewTab) {
-          window.open(alarm.backUrl, '_blank', 'noopener,noreferrer')
+        const targetHost = urlObj.host
+        const isSameOrigin = urlObj.origin === window.location.origin
+        const shouldNewTab = !isSameOrigin && backendHost !== targetHost
+
+        if (isSameOrigin) {
+          navigate(urlObj.pathname + urlObj.search + urlObj.hash)
+        } else if (shouldNewTab) {
+          window.open(urlObj.toString(), '_blank', 'noopener,noreferrer')
         } else {
-          window.location.href = alarm.backUrl
+          window.location.href = urlObj.toString()
         }
       })
       .catch(() => {

--- a/src/components/postings/manage/ApplicantDetailModal.tsx
+++ b/src/components/postings/manage/ApplicantDetailModal.tsx
@@ -18,6 +18,7 @@ type ApplicantDetailModalProps = {
   applicant: ApplicantDetail | null
   onApprove?: (id: string) => void
   onReject?: (id: string) => void
+  isLoading?: boolean
 }
 
 export default function ApplicantDetailModal({
@@ -26,10 +27,11 @@ export default function ApplicantDetailModal({
   applicant,
   onApprove,
   onReject,
+  isLoading,
 }: ApplicantDetailModalProps) {
-  if (!applicant) return null
+  if (!applicant && !isLoading) return null
 
-  const showFooter = applicant.status === 'PENDING'
+  const showFooter = applicant?.status === 'PENDING'
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -60,7 +62,7 @@ export default function ApplicantDetailModal({
             </h4>
             <div className="flex items-center gap-3">
               <div className="h-14 w-14 overflow-hidden rounded-full bg-gray-100">
-                {applicant.thumbnail ? (
+                {applicant?.thumbnail ? (
                   <img
                     src={applicant.thumbnail}
                     alt={applicant.name}
@@ -72,10 +74,10 @@ export default function ApplicantDetailModal({
               </div>
               <div className="flex flex-col gap-1">
                 <span className="text-base font-semibold">
-                  {applicant.name}
+                  {applicant?.name ?? '로딩 중'}
                 </span>
                 <span className="text-sm text-gray-600">
-                  {applicant.gender}
+                  {applicant?.gender ?? ''}
                 </span>
               </div>
             </div>
@@ -85,31 +87,44 @@ export default function ApplicantDetailModal({
             <div className="flex items-start justify-between gap-4">
               <div className="flex flex-col gap-1 text-sm text-gray-700">
                 <span className="text-gray-500">지원 상태</span>
-                <Badge variant={applicantStatusColor[applicant.status]}>
-                  {applicantStatusLabel[applicant.status]}
+                <Badge
+                  variant={
+                    applicant
+                      ? applicantStatusColor[applicant.status]
+                      : 'default'
+                  }
+                >
+                  {applicant ? applicantStatusLabel[applicant.status] : '...'}
                 </Badge>
               </div>
               <div className="flex flex-col items-end gap-1 text-sm text-gray-700">
                 <span className="text-gray-500">지원 일시</span>
-                <span>{applicant.appliedAt}</span>
+                <span>{applicant?.appliedAt ?? '...'}</span>
               </div>
             </div>
           </div>
 
-          <Section title="자기소개" content={applicant.selfIntro} />
-          <Section title="지원동기" content={applicant.motivation} />
-          <Section title="스터디 목표" content={applicant.goal} />
-          <Section title="가능한 시간대" content={applicant.availableTime} />
+          <Section title="자기소개" content={applicant?.selfIntro ?? '...'} />
+          <Section title="지원동기" content={applicant?.motivation ?? '...'} />
+          <Section title="스터디 목표" content={applicant?.goal ?? '...'} />
+          <Section
+            title="가능한 시간대"
+            content={applicant?.availableTime ?? '...'}
+          />
           <div>
             <h5 className="mb-2 text-sm font-semibold text-gray-700">
               스터디 경험
             </h5>
             <div className="flex flex-col gap-2 rounded-lg bg-gray-50 p-4">
-              <Badge variant={applicant.hasExperience ? 'success' : 'danger'}>
-                {applicant.hasExperience ? '경험 있음' : '경험 없음'}
+              <Badge variant={applicant?.hasExperience ? 'success' : 'danger'}>
+                {applicant
+                  ? applicant.hasExperience
+                    ? '경험 있음'
+                    : '경험 없음'
+                  : '...'}
               </Badge>
               <p className="text-sm whitespace-pre-line text-gray-700">
-                {applicant.experienceDetail}
+                {applicant?.experienceDetail ?? '...'}
               </p>
             </div>
           </div>
@@ -120,7 +135,7 @@ export default function ApplicantDetailModal({
             <Button
               variant="danger"
               className="w-[84px]"
-              onClick={() => onReject?.(applicant.id)}
+              onClick={() => applicant && onReject?.(applicant.id)}
             >
               {getTypeIcon('rejected')}
               거절
@@ -128,7 +143,7 @@ export default function ApplicantDetailModal({
             <Button
               variant="success"
               className="w-[84px]"
-              onClick={() => onApprove?.(applicant.id)}
+              onClick={() => applicant && onApprove?.(applicant.id)}
             >
               {getTypeIcon('approved')}
               승인

--- a/src/components/postings/manage/ApplicantDetailModal.tsx
+++ b/src/components/postings/manage/ApplicantDetailModal.tsx
@@ -19,6 +19,7 @@ type ApplicantDetailModalProps = {
   onApprove?: (id: string) => void
   onReject?: (id: string) => void
   isLoading?: boolean
+  isActionLoading?: boolean
 }
 
 export default function ApplicantDetailModal({
@@ -28,6 +29,7 @@ export default function ApplicantDetailModal({
   onApprove,
   onReject,
   isLoading,
+  isActionLoading,
 }: ApplicantDetailModalProps) {
   if (!applicant && !isLoading) return null
 
@@ -136,17 +138,19 @@ export default function ApplicantDetailModal({
               variant="danger"
               className="w-[84px]"
               onClick={() => applicant && onReject?.(applicant.id)}
+              disabled={isActionLoading}
             >
               {getTypeIcon('rejected')}
-              거절
+              {isActionLoading ? '처리 중' : '거절'}
             </Button>
             <Button
               variant="success"
               className="w-[84px]"
               onClick={() => applicant && onApprove?.(applicant.id)}
+              disabled={isActionLoading}
             >
               {getTypeIcon('approved')}
-              승인
+              {isActionLoading ? '처리 중' : '승인'}
             </Button>
           </DialogFooter>
         )}

--- a/src/components/postings/manage/ManageApplicantsModal.tsx
+++ b/src/components/postings/manage/ManageApplicantsModal.tsx
@@ -7,6 +7,7 @@ import { applicantStatusColor, applicantStatusLabel } from './applicantStatus'
 import type { Applicant } from './applicantTypes'
 import { useEffect, useRef, useState } from 'react'
 import { useInView } from 'react-intersection-observer'
+import CardSkeleton from '@/components/common/CardSkeleton'
 
 type ManageApplicantsModalProps = {
   open: boolean
@@ -54,6 +55,8 @@ export default function ManageApplicantsModal({
     })
   }, [inView, hasNextPage, isFetchingNext, onLoadMore])
 
+  const noData = !isLoading && applicants.length === 0
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
@@ -80,21 +83,30 @@ export default function ManageApplicantsModal({
           ref={listRef}
           className="grid h-[calc(80dvh-100px)] grid-cols-1 gap-3 overflow-y-auto p-4 sm:h-auto sm:p-6 md:grid-cols-2"
         >
-          {(isLoading ? renderSkeletons : applicants).map((item, idx) => {
-            const applicant = isLoading
-              ? undefined
-              : (item as Applicant | undefined)
-            const key = applicant?.id ?? `skeleton-${idx}`
-            return (
+          {isLoading &&
+            renderSkeletons.map((_, idx) => <CardSkeleton key={`sk-${idx}`} />)}
+
+          {!isLoading &&
+            !noData &&
+            applicants.map((applicant) => (
               <ApplicantCard
-                key={key}
+                key={applicant.id}
                 applicant={applicant}
-                onClick={() =>
-                  applicant ? onApplicantClick?.(applicant.id) : undefined
-                }
+                onClick={() => onApplicantClick?.(applicant.id)}
               />
-            )
-          })}
+            ))}
+
+          {noData && (
+            <div className="col-span-2 flex flex-col items-center justify-center rounded-lg border border-dashed border-gray-200 bg-white p-8 text-sm text-gray-500">
+              <span className="text-base font-semibold text-gray-700">
+                지원자가 없습니다
+              </span>
+              <span className="text-xs text-gray-400">
+                새로운 지원자가 등록되면 이곳에 표시됩니다
+              </span>
+            </div>
+          )}
+
           <div ref={setSentinelRef} aria-hidden />
         </div>
       </DialogContent>

--- a/src/components/postings/manage/ManageApplicantsModal.tsx
+++ b/src/components/postings/manage/ManageApplicantsModal.tsx
@@ -5,7 +5,8 @@ import { getTypeIcon } from '@/helpers/icons'
 import { Button } from '@/components/common'
 import { applicantStatusColor, applicantStatusLabel } from './applicantStatus'
 import type { Applicant } from './applicantTypes'
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import { useInView } from 'react-intersection-observer'
 
 type ManageApplicantsModalProps = {
   open: boolean
@@ -16,7 +17,7 @@ type ManageApplicantsModalProps = {
   isLoading?: boolean
   isFetchingNext?: boolean
   hasNextPage?: boolean
-  onLoadMore?: () => void
+  onLoadMore?: () => Promise<unknown> | void
   onApplicantClick?: (id: string) => void
 }
 
@@ -33,6 +34,25 @@ export default function ManageApplicantsModal({
   onApplicantClick,
 }: ManageApplicantsModalProps) {
   const renderSkeletons = Array.from({ length: 6 })
+  const listRef = useRef<HTMLDivElement | null>(null)
+  const loadingRef = useRef(false)
+  const lastFetchRef = useRef(0)
+  const { ref: setSentinelRef, inView } = useInView({
+    root: listRef.current,
+    rootMargin: '120px 0px',
+    threshold: 0,
+  })
+
+  useEffect(() => {
+    if (!inView || !hasNextPage || isFetchingNext || loadingRef.current) return
+    const now = Date.now()
+    if (now - lastFetchRef.current < 400) return
+    lastFetchRef.current = now
+    loadingRef.current = true
+    Promise.resolve(onLoadMore?.()).finally(() => {
+      loadingRef.current = false
+    })
+  }, [inView, hasNextPage, isFetchingNext, onLoadMore])
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -56,7 +76,10 @@ export default function ManageApplicantsModal({
             </Button>
           </DialogClose>
         </div>
-        <div className="grid h-[calc(80dvh-100px)] grid-cols-1 gap-3 overflow-y-auto p-4 sm:h-auto sm:p-6 md:grid-cols-2">
+        <div
+          ref={listRef}
+          className="grid h-[calc(80dvh-100px)] grid-cols-1 gap-3 overflow-y-auto p-4 sm:h-auto sm:p-6 md:grid-cols-2"
+        >
           {(isLoading ? renderSkeletons : applicants).map((item, idx) => {
             const applicant = isLoading
               ? undefined
@@ -72,18 +95,8 @@ export default function ManageApplicantsModal({
               />
             )
           })}
+          <div ref={setSentinelRef} aria-hidden />
         </div>
-        {hasNextPage && (
-          <div className="flex justify-center border-t border-gray-200 p-4">
-            <Button
-              variant="outline"
-              onClick={onLoadMore}
-              disabled={isFetchingNext}
-            >
-              {isFetchingNext ? '불러오는 중...' : '더 불러오기'}
-            </Button>
-          </div>
-        )}
       </DialogContent>
     </Dialog>
   )

--- a/src/components/postings/manage/ManageApplicantsModal.tsx
+++ b/src/components/postings/manage/ManageApplicantsModal.tsx
@@ -5,6 +5,7 @@ import { getTypeIcon } from '@/helpers/icons'
 import { Button } from '@/components/common'
 import { applicantStatusColor, applicantStatusLabel } from './applicantStatus'
 import type { Applicant } from './applicantTypes'
+import { useState } from 'react'
 
 type ManageApplicantsModalProps = {
   open: boolean
@@ -12,6 +13,10 @@ type ManageApplicantsModalProps = {
   recruitmentTitle: string
   totalCount: number
   applicants: Applicant[]
+  isLoading?: boolean
+  isFetchingNext?: boolean
+  hasNextPage?: boolean
+  onLoadMore?: () => void
   onApplicantClick?: (id: string) => void
 }
 
@@ -21,8 +26,14 @@ export default function ManageApplicantsModal({
   recruitmentTitle,
   totalCount,
   applicants,
+  isLoading,
+  isFetchingNext,
+  hasNextPage,
+  onLoadMore,
   onApplicantClick,
 }: ManageApplicantsModalProps) {
+  const renderSkeletons = Array.from({ length: 6 })
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
@@ -46,66 +57,110 @@ export default function ManageApplicantsModal({
           </DialogClose>
         </div>
         <div className="grid h-[calc(80dvh-100px)] grid-cols-1 gap-3 overflow-y-auto p-4 sm:h-auto sm:p-6 md:grid-cols-2">
-          {applicants.map((applicant) => (
-            <div
-              onClick={() => onApplicantClick?.(applicant.id)}
-              className="flex cursor-pointer gap-3 rounded-lg bg-gray-100 p-4 text-left transition hover:bg-gray-200"
-              key={applicant.id}
-            >
-              <div className="h-12 w-12 shrink-0 overflow-hidden rounded-full">
-                {applicant.thumbnail ? (
-                  <img
-                    src={applicant.thumbnail}
-                    alt={applicant.name}
-                    className="h-full w-full object-cover"
-                  />
-                ) : (
-                  <Skeleton className="h-full w-full bg-gray-400" />
-                )}
-              </div>
-              <div className="flex flex-1 flex-col gap-2">
-                <div className="flex-between gap-2">
-                  <div className="flex flex-col gap-1">
-                    <span className="text-base font-semibold">
-                      {applicant.name}
-                    </span>
-                    <span className="text-sm text-gray-600">
-                      {applicant.gender}
-                    </span>
-                  </div>
-                  <Badge variant={applicantStatusColor[applicant.status]}>
-                    {applicantStatusLabel[applicant.status]}
-                  </Badge>
-                </div>
-                <div className="text-sm text-gray-700">
-                  <div className="mb-3 flex items-center gap-1">
-                    <span className="text-gray-500">지원 일시:</span>
-                    <span>{applicant.appliedAt}</span>
-                  </div>
-                  <div className="mb-3 flex flex-col">
-                    <span className="mb-1 text-[12px] font-medium text-gray-700">
-                      가능한 시간대
-                    </span>
-                    <span className="line-clamp-2">
-                      {applicant.availableTime}
-                    </span>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <span className="text-[12px] font-medium text-gray-700">
-                      스터디 경험
-                    </span>
-                    <Badge
-                      variant={applicant.hasExperience ? 'success' : 'danger'}
-                    >
-                      {applicant.hasExperience ? '경험 있음' : '경험 없음'}
-                    </Badge>
-                  </div>
-                </div>
-              </div>
-            </div>
-          ))}
+          {(isLoading ? renderSkeletons : applicants).map((item, idx) => {
+            const applicant = isLoading
+              ? undefined
+              : (item as Applicant | undefined)
+            const key = applicant?.id ?? `skeleton-${idx}`
+            return (
+              <ApplicantCard
+                key={key}
+                applicant={applicant}
+                onClick={() =>
+                  applicant ? onApplicantClick?.(applicant.id) : undefined
+                }
+              />
+            )
+          })}
         </div>
+        {hasNextPage && (
+          <div className="flex justify-center border-t border-gray-200 p-4">
+            <Button
+              variant="outline"
+              onClick={onLoadMore}
+              disabled={isFetchingNext}
+            >
+              {isFetchingNext ? '불러오는 중...' : '더 불러오기'}
+            </Button>
+          </div>
+        )}
       </DialogContent>
     </Dialog>
+  )
+}
+
+function ApplicantCard({
+  applicant,
+  onClick,
+}: {
+  applicant?: Applicant
+  onClick?: () => void
+}) {
+  const [imgOk, setImgOk] = useState(true)
+  const showImg = applicant?.thumbnail && imgOk
+
+  return (
+    <div
+      onClick={onClick}
+      className={`flex cursor-pointer gap-3 rounded-lg bg-gray-100 p-4 text-left transition ${applicant ? 'hover:bg-gray-200' : ''}`}
+    >
+      <div className="h-12 w-12 shrink-0 overflow-hidden rounded-full">
+        {showImg ? (
+          <img
+            src={applicant?.thumbnail}
+            alt={applicant?.name ?? '지원자'}
+            className="h-full w-full object-cover"
+            onError={() => setImgOk(false)}
+          />
+        ) : (
+          <Skeleton className="h-full w-full bg-gray-400" />
+        )}
+      </div>
+      <div className="flex flex-1 flex-col gap-2">
+        <div className="flex-between gap-2">
+          <div className="flex flex-col gap-1">
+            <span className="text-base font-semibold">
+              {applicant?.name ?? '로딩 중'}
+            </span>
+            <span className="text-sm text-gray-600">
+              {applicant?.gender ?? ''}
+            </span>
+          </div>
+          <Badge
+            variant={
+              applicant ? applicantStatusColor[applicant.status] : 'default'
+            }
+          >
+            {applicant ? applicantStatusLabel[applicant.status] : '...'}
+          </Badge>
+        </div>
+        <div className="text-sm text-gray-700">
+          <div className="mb-3 flex items-center gap-1">
+            <span className="text-gray-500">지원 일시:</span>
+            <span>{applicant?.appliedAt ?? '...'}</span>
+          </div>
+          <div className="mb-3 flex flex-col">
+            <span className="mb-1 text-[12px] font-medium text-gray-700">
+              가능한 시간대
+            </span>
+            <span className="line-clamp-2">
+              {applicant?.availableTime ?? '...'}
+            </span>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="text-[12px] font-medium text-gray-700">
+              스터디 경험
+            </span>
+            <Badge variant={applicant?.hasExperience ? 'success' : 'danger'}>
+              {applicant
+                ? applicant.hasExperience
+                  ? '경험 있음'
+                  : '경험 없음'
+                : '...'}
+            </Badge>
+          </div>
+        </div>
+      </div>
+    </div>
   )
 }

--- a/src/components/postings/manage/ManageCard.tsx
+++ b/src/components/postings/manage/ManageCard.tsx
@@ -90,7 +90,7 @@ export default function ManageCard({
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
   const navigate = useNavigate()
-  const applicantsQuery = useApplicants(posting.uuid)
+  const applicantsQuery = useApplicants(posting.uuid, 10, isModalOpen)
   const applicantList =
     applicantsQuery.data?.pages.flatMap((page) => page.results) ?? []
   const totalApplicants = applicantList.length

--- a/src/components/postings/manage/ManageCard.tsx
+++ b/src/components/postings/manage/ManageCard.tsx
@@ -1,5 +1,5 @@
 import { Bookmark, Calendar, Eye, Pencil, Trash2, Users } from 'lucide-react'
-import { useMemo, useState } from 'react'
+import { useState } from 'react'
 import { useNavigate } from 'react-router'
 
 import { Button, Modal } from '@/components/common'
@@ -13,6 +13,7 @@ import { deleteMyRecruitment } from '@/api/myRecruitment'
 import { showToast } from '@/components/common/toast/Toast'
 import ManageApplicantsModal from './ManageApplicantsModal'
 import { useApplicants } from '@/hooks/quries/useApplicants'
+import { useApplicantDetail } from '@/hooks/quries/useApplicantDetail'
 
 type ManageCardProps = {
   posting: ManageRecruitment
@@ -81,30 +82,30 @@ export default function ManageCard({ posting, onDeleted }: ManageCardProps) {
   const [isDeleting, setIsDeleting] = useState(false)
   const navigate = useNavigate()
   const applicantsQuery = useApplicants(posting.uuid)
-  const applicantList = useMemo(
-    () => applicantsQuery.data?.pages.flatMap((page) => page.results) ?? [],
-    [applicantsQuery.data]
-  )
+  const applicantList =
+    applicantsQuery.data?.pages.flatMap((page) => page.results) ?? []
   const totalApplicants = applicantList.length
+  const detailQuery = useApplicantDetail(selectedApplicantId ?? undefined)
 
-  const handleLoadMore = () => {
+  const handleLoadMore = async () => {
     if (applicantsQuery.hasNextPage && !applicantsQuery.isFetchingNextPage) {
-      applicantsQuery.fetchNextPage()
+      await applicantsQuery.fetchNextPage()
     }
   }
 
-  const selectedApplicant: ApplicantDetail | null = useMemo(() => {
-    const target = applicantList.find((a) => a.id === selectedApplicantId)
-    if (!target) return null
-    // 상세 API가 아직 없으므로 리스트 데이터를 기반으로 간략히 노출
-    return {
-      ...target,
-      selfIntro: '자기소개 정보가 준비 중입니다.',
-      motivation: '지원 동기 정보가 준비 중입니다.',
-      goal: '스터디 목표 정보가 준비 중입니다.',
-      experienceDetail: '스터디 경험 상세가 준비 중입니다.',
-    }
-  }, [applicantList, selectedApplicantId])
+  const fallbackApplicant =
+    applicantList.find((a) => a.id === selectedApplicantId) ?? null
+  const selectedApplicant: ApplicantDetail | null =
+    detailQuery.data ??
+    (fallbackApplicant
+      ? {
+          ...fallbackApplicant,
+          selfIntro: '자기소개 정보가 준비 중입니다.',
+          motivation: '지원 동기 정보가 준비 중입니다.',
+          goal: '스터디 목표 정보가 준비 중입니다.',
+          experienceDetail: '스터디 경험 상세가 준비 중입니다.',
+        }
+      : null)
 
   const handleDelete = async () => {
     setIsDeleting(true)
@@ -231,6 +232,7 @@ export default function ManageCard({ posting, onDeleted }: ManageCardProps) {
           setSelectedApplicantId(open ? selectedApplicantId : null)
         }
         applicant={selectedApplicant}
+        isLoading={detailQuery.isLoading}
       />
       <ConfirmDeleteModal
         open={isDeleteModalOpen}

--- a/src/components/postings/manage/ManageCard.tsx
+++ b/src/components/postings/manage/ManageCard.tsx
@@ -1,5 +1,5 @@
 import { Bookmark, Calendar, Eye, Pencil, Trash2, Users } from 'lucide-react'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useNavigate } from 'react-router'
 
 import { Button, Modal } from '@/components/common'
@@ -8,10 +8,11 @@ import { Skeleton } from '@/components/common/skeleton'
 import { getTypeIcon } from '@/helpers/icons'
 import type { ManageRecruitment } from '@/types/myRecruitment'
 import ApplicantDetailModal from './ApplicantDetailModal'
-import type { Applicant, ApplicantDetail } from './applicantTypes'
+import type { ApplicantDetail } from './applicantTypes'
 import { deleteMyRecruitment } from '@/api/myRecruitment'
 import { showToast } from '@/components/common/toast/Toast'
 import ManageApplicantsModal from './ManageApplicantsModal'
+import { useApplicants } from '@/hooks/quries/useApplicants'
 
 type ManageCardProps = {
   posting: ManageRecruitment
@@ -79,75 +80,31 @@ export default function ManageCard({ posting, onDeleted }: ManageCardProps) {
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
   const navigate = useNavigate()
-  // TODO: api 연동 필요
-  const mockApplicants: Applicant[] = [
-    {
-      id: '1',
-      name: '김지원',
-      gender: '여성',
-      status: 'PENDING' as const,
-      appliedAt: '2024-11-25 14:30',
-      availableTime:
-        '평일 저녁 7-10시, 주말 오후 시간대 참여 가능합니다. 평일 저녁 7-10시, 주말 오후 시간대 참여 가능합니다. 평일 저녁 7-10시, 주말 오후 시간대 참여 가능합니다.',
-      hasExperience: false,
-      thumbnail: '',
-    },
-    {
-      id: '2',
-      name: '박개발',
-      gender: '남성',
-      status: 'ACCEPTED' as const,
-      appliedAt: '2024-11-24 10:10',
-      availableTime: '주말 오전/오후, 평일 9시 이후 가능',
-      hasExperience: true,
-      thumbnail: '',
-    },
-    {
-      id: '3',
-      name: '최코딩',
-      gender: '여성',
-      status: 'REJECTED' as const,
-      appliedAt: '2024-11-23 20:45',
-      availableTime: '평일 오후 6-8시',
-      hasExperience: true,
-      thumbnail: '',
-    },
-    {
-      id: '4',
-      name: '이프론트',
-      gender: '남성',
-      status: 'PENDING' as const,
-      appliedAt: '2024-11-22 09:20',
-      availableTime: '주중 8-10시, 주말 오후',
-      hasExperience: false,
-      thumbnail: '',
-    },
-    {
-      id: '5',
-      name: '이프론트',
-      gender: '남성',
-      status: 'CANCELED' as const,
-      appliedAt: '2024-11-22 09:20',
-      availableTime: '주중 8-10시, 주말 오후',
-      hasExperience: false,
-      thumbnail: '',
-    },
-  ]
-
-  const applicantDetails: ApplicantDetail[] = mockApplicants.map(
-    (applicant) => ({
-      ...applicant,
-      selfIntro: '안녕하세요, 백엔드 개발자로 성장하고 싶은 지원자입니다.',
-      motivation:
-        'Node.js 실무 경험을 쌓고 협업 역량을 키우기 위해 지원했습니다.',
-      goal: '스터디를 통해 프로젝트 완성도를 높이고 코드 리뷰를 통해 성장하고 싶습니다.',
-      experienceDetail:
-        '이전에 소규모 스터디에 참여한 경험이 있으며, 주로 서버 API 개발을 맡았습니다.',
-    })
+  const applicantsQuery = useApplicants(posting.uuid)
+  const applicantList = useMemo(
+    () => applicantsQuery.data?.pages.flatMap((page) => page.results) ?? [],
+    [applicantsQuery.data]
   )
+  const totalApplicants = applicantList.length
 
-  const selectedApplicant =
-    applicantDetails.find((a) => a.id === selectedApplicantId) ?? null
+  const handleLoadMore = () => {
+    if (applicantsQuery.hasNextPage && !applicantsQuery.isFetchingNextPage) {
+      applicantsQuery.fetchNextPage()
+    }
+  }
+
+  const selectedApplicant: ApplicantDetail | null = useMemo(() => {
+    const target = applicantList.find((a) => a.id === selectedApplicantId)
+    if (!target) return null
+    // 상세 API가 아직 없으므로 리스트 데이터를 기반으로 간략히 노출
+    return {
+      ...target,
+      selfIntro: '자기소개 정보가 준비 중입니다.',
+      motivation: '지원 동기 정보가 준비 중입니다.',
+      goal: '스터디 목표 정보가 준비 중입니다.',
+      experienceDetail: '스터디 경험 상세가 준비 중입니다.',
+    }
+  }, [applicantList, selectedApplicantId])
 
   const handleDelete = async () => {
     setIsDeleting(true)
@@ -260,8 +217,12 @@ export default function ManageCard({ posting, onDeleted }: ManageCardProps) {
         open={isModalOpen}
         onOpenChange={setIsModalOpen}
         recruitmentTitle={posting.title}
-        totalCount={mockApplicants.length}
-        applicants={mockApplicants}
+        totalCount={totalApplicants}
+        applicants={applicantList}
+        isLoading={applicantsQuery.isLoading}
+        isFetchingNext={applicantsQuery.isFetchingNextPage}
+        hasNextPage={applicantsQuery.hasNextPage}
+        onLoadMore={handleLoadMore}
         onApplicantClick={(id) => setSelectedApplicantId(id)}
       />
       <ApplicantDetailModal

--- a/src/components/postings/manage/ManageCard.tsx
+++ b/src/components/postings/manage/ManageCard.tsx
@@ -1,5 +1,5 @@
 import { Bookmark, Calendar, Eye, Pencil, Trash2, Users } from 'lucide-react'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router'
 
 import { Button, Modal } from '@/components/common'
@@ -20,6 +20,8 @@ import { approveApplication, rejectApplication } from '@/api/applications'
 type ManageCardProps = {
   posting: ManageRecruitment
   onDeleted?: () => void
+  autoOpen?: boolean
+  onAutoOpenConsumed?: () => void
 }
 
 type DeleteModalProps = {
@@ -74,7 +76,12 @@ function ConfirmDeleteModal({
   )
 }
 
-export default function ManageCard({ posting, onDeleted }: ManageCardProps) {
+export default function ManageCard({
+  posting,
+  onDeleted,
+  autoOpen = false,
+  onAutoOpenConsumed,
+}: ManageCardProps) {
   const [imgLoaded, setImgLoaded] = useState(false)
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [selectedApplicantId, setSelectedApplicantId] = useState<string | null>(
@@ -117,6 +124,12 @@ export default function ManageCard({ posting, onDeleted }: ManageCardProps) {
       await applicantsQuery.fetchNextPage()
     }
   }
+
+  useEffect(() => {
+    if (!autoOpen || isModalOpen) return
+    setIsModalOpen(true)
+    onAutoOpenConsumed?.()
+  }, [autoOpen, isModalOpen, onAutoOpenConsumed])
 
   const selectedApplicant: ApplicantDetail | null = detailQuery.data ?? null
 

--- a/src/components/postings/manage/ManageCard.tsx
+++ b/src/components/postings/manage/ManageCard.tsx
@@ -14,6 +14,8 @@ import { showToast } from '@/components/common/toast/Toast'
 import ManageApplicantsModal from './ManageApplicantsModal'
 import { useApplicants } from '@/hooks/quries/useApplicants'
 import { useApplicantDetail } from '@/hooks/quries/useApplicantDetail'
+import { useMutation } from '@tanstack/react-query'
+import { approveApplication, rejectApplication } from '@/api/applications'
 
 type ManageCardProps = {
   posting: ManageRecruitment
@@ -86,6 +88,29 @@ export default function ManageCard({ posting, onDeleted }: ManageCardProps) {
     applicantsQuery.data?.pages.flatMap((page) => page.results) ?? []
   const totalApplicants = applicantList.length
   const detailQuery = useApplicantDetail(selectedApplicantId ?? undefined)
+  const approveMutation = useMutation({
+    mutationFn: (id: number) => approveApplication(id),
+    onSuccess: () => {
+      showToast.success('승인 완료', '지원이 승인되었습니다.')
+      applicantsQuery.refetch()
+      detailQuery.refetch()
+    },
+    onError: (err) => {
+      showToast.error('승인 실패', (err as Error)?.message ?? '')
+    },
+  })
+
+  const rejectMutation = useMutation({
+    mutationFn: (id: number) => rejectApplication(id),
+    onSuccess: () => {
+      showToast.success('거절 완료', '지원이 거절되었습니다.')
+      applicantsQuery.refetch()
+      detailQuery.refetch()
+    },
+    onError: (err) => {
+      showToast.error('거절 실패', (err as Error)?.message ?? '')
+    },
+  })
 
   const handleLoadMore = async () => {
     if (applicantsQuery.hasNextPage && !applicantsQuery.isFetchingNextPage) {
@@ -93,19 +118,7 @@ export default function ManageCard({ posting, onDeleted }: ManageCardProps) {
     }
   }
 
-  const fallbackApplicant =
-    applicantList.find((a) => a.id === selectedApplicantId) ?? null
-  const selectedApplicant: ApplicantDetail | null =
-    detailQuery.data ??
-    (fallbackApplicant
-      ? {
-          ...fallbackApplicant,
-          selfIntro: '자기소개 정보가 준비 중입니다.',
-          motivation: '지원 동기 정보가 준비 중입니다.',
-          goal: '스터디 목표 정보가 준비 중입니다.',
-          experienceDetail: '스터디 경험 상세가 준비 중입니다.',
-        }
-      : null)
+  const selectedApplicant: ApplicantDetail | null = detailQuery.data ?? null
 
   const handleDelete = async () => {
     setIsDeleting(true)
@@ -233,6 +246,17 @@ export default function ManageCard({ posting, onDeleted }: ManageCardProps) {
         }
         applicant={selectedApplicant}
         isLoading={detailQuery.isLoading}
+        onApprove={
+          selectedApplicantId
+            ? () => approveMutation.mutate(Number(selectedApplicantId))
+            : undefined
+        }
+        onReject={
+          selectedApplicantId
+            ? () => rejectMutation.mutate(Number(selectedApplicantId))
+            : undefined
+        }
+        isActionLoading={approveMutation.isPending || rejectMutation.isPending}
       />
       <ConfirmDeleteModal
         open={isDeleteModalOpen}

--- a/src/components/postings/manage/ManageList.tsx
+++ b/src/components/postings/manage/ManageList.tsx
@@ -6,12 +6,16 @@ type ManageListProps = {
   postings: ManageRecruitment[]
   isLoading?: boolean
   onDeleted?: () => void
+  autoOpenId?: string | null
+  onAutoOpenConsumed?: () => void
 }
 
 export default function ManageList({
   postings,
   isLoading,
   onDeleted,
+  autoOpenId,
+  onAutoOpenConsumed,
 }: ManageListProps) {
   if (isLoading) {
     return <ManageCardSkeleton count={6} />
@@ -27,13 +31,18 @@ export default function ManageList({
 
   return (
     <div className="grid grid-cols-1 gap-4">
-      {postings.map((posting) => (
-        <ManageCard
-          key={posting.uuid}
-          posting={posting}
-          onDeleted={onDeleted}
-        />
-      ))}
+      {postings.map((posting) => {
+        const shouldAutoOpen = !!autoOpenId && posting.uuid === autoOpenId
+        return (
+          <ManageCard
+            key={posting.uuid}
+            posting={posting}
+            onDeleted={onDeleted}
+            autoOpen={shouldAutoOpen}
+            onAutoOpenConsumed={onAutoOpenConsumed}
+          />
+        )
+      })}
     </div>
   )
 }

--- a/src/hooks/quries/useApplicantDetail.ts
+++ b/src/hooks/quries/useApplicantDetail.ts
@@ -1,0 +1,51 @@
+import { useQuery } from '@tanstack/react-query'
+import { axiosInstance } from '@/api/axios'
+import type { ApplicantDetail } from '@/components/postings/manage/applicantTypes'
+
+type ApplicantDetailResponse = {
+  id: number
+  uuid: string
+  status: string
+  created_at: string
+  updated_at: string
+  applicant: {
+    id: number
+    nickname: string
+    gender: string
+    profile_img_url: string | null
+  }
+  self_introduction: string
+  motivation: string
+  objective: string
+  available_time: string
+  has_study_experience: boolean
+  study_experience: string
+}
+
+const mapApplicantDetail = (res: ApplicantDetailResponse): ApplicantDetail => ({
+  id: res.uuid ?? String(res.id),
+  name: res.applicant?.nickname ?? '알 수 없음',
+  gender: res.applicant?.gender ?? '',
+  status: (res.status as any) ?? 'PENDING',
+  appliedAt: res.created_at ?? '',
+  availableTime: res.available_time ?? '',
+  hasExperience: !!res.has_study_experience,
+  thumbnail: res.applicant?.profile_img_url ?? undefined,
+  selfIntro: res.self_introduction ?? '',
+  motivation: res.motivation ?? '',
+  goal: res.objective ?? '',
+  experienceDetail: res.study_experience ?? '',
+})
+
+export const useApplicantDetail = (applicationId?: string) =>
+  useQuery({
+    queryKey: ['applicant-detail', applicationId],
+    enabled: !!applicationId,
+    queryFn: async () => {
+      const { data } = await axiosInstance.get<ApplicantDetailResponse>(
+        `/v1/applications/${applicationId}/review`
+      )
+      return mapApplicantDetail(data)
+    },
+    placeholderData: (prev) => prev,
+  })

--- a/src/hooks/quries/useApplicants.ts
+++ b/src/hooks/quries/useApplicants.ts
@@ -36,7 +36,11 @@ const mapApplicant = (item: ApplicantApiItem): Applicant => ({
   thumbnail: item.applicant?.profile_img_url ?? undefined,
 })
 
-export const useApplicants = (recruitmentUuid?: string, pageSize = 10) =>
+export const useApplicants = (
+  recruitmentUuid?: string,
+  pageSize = 10,
+  enabled = true
+) =>
   useInfiniteQuery({
     queryKey: ['applicants', recruitmentUuid],
     queryFn: async ({ pageParam }) => {
@@ -48,7 +52,7 @@ export const useApplicants = (recruitmentUuid?: string, pageSize = 10) =>
       )
       return data
     },
-    enabled: !!recruitmentUuid,
+    enabled: !!recruitmentUuid && enabled,
     initialPageParam: undefined as string | undefined,
     getNextPageParam: (lastPage) => lastPage.next ?? undefined,
     placeholderData: (prev) => prev,

--- a/src/hooks/quries/useApplicants.ts
+++ b/src/hooks/quries/useApplicants.ts
@@ -25,7 +25,8 @@ type ApplicantListResponse = {
 }
 
 const mapApplicant = (item: ApplicantApiItem): Applicant => ({
-  id: item.uuid ?? String(item.id),
+  // 백엔드 상세 조회는 application id 기반이라 id를 우선 사용
+  id: String(item.id),
   name: item.applicant?.nickname ?? '알 수 없음',
   gender: item.applicant?.gender ?? '',
   status: (item.status as any) ?? 'PENDING',

--- a/src/hooks/quries/useApplicants.ts
+++ b/src/hooks/quries/useApplicants.ts
@@ -1,0 +1,61 @@
+import { useInfiniteQuery } from '@tanstack/react-query'
+import { axiosInstance } from '@/api/axios'
+import type { Applicant } from '@/components/postings/manage/applicantTypes'
+
+type ApplicantApiItem = {
+  id: number
+  uuid: string
+  status: string
+  created_at: string
+  updated_at: string
+  applicant: {
+    id: number
+    nickname: string
+    gender: string
+    profile_img_url: string | null
+  }
+  available_time: string
+  has_study_experience: boolean
+}
+
+type ApplicantListResponse = {
+  next: string | null
+  previous: string | null
+  results: ApplicantApiItem[]
+}
+
+const mapApplicant = (item: ApplicantApiItem): Applicant => ({
+  id: item.uuid ?? String(item.id),
+  name: item.applicant?.nickname ?? '알 수 없음',
+  gender: item.applicant?.gender ?? '',
+  status: (item.status as any) ?? 'PENDING',
+  appliedAt: item.created_at ?? '',
+  availableTime: item.available_time ?? '',
+  hasExperience: !!item.has_study_experience,
+  thumbnail: item.applicant?.profile_img_url ?? undefined,
+})
+
+export const useApplicants = (recruitmentUuid?: string, pageSize = 10) =>
+  useInfiniteQuery({
+    queryKey: ['applicants', recruitmentUuid],
+    queryFn: async ({ pageParam }) => {
+      const { data } = await axiosInstance.get<ApplicantListResponse>(
+        pageParam || `/v1/recruitments/${recruitmentUuid}/applicants`,
+        {
+          params: pageParam ? undefined : { page_size: pageSize },
+        }
+      )
+      return data
+    },
+    enabled: !!recruitmentUuid,
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) => lastPage.next ?? undefined,
+    placeholderData: (prev) => prev,
+    select: (data) => ({
+      pageParams: data.pageParams,
+      pages: data.pages.map((page) => ({
+        ...page,
+        results: page.results.map(mapApplicant),
+      })),
+    }),
+  })

--- a/src/pages/postings/Manage.tsx
+++ b/src/pages/postings/Manage.tsx
@@ -7,12 +7,14 @@ import { useState, useEffect } from 'react'
 import type { MyRecruitmentParams } from '@/types/myRecruitment'
 import { useMyRecruitments } from '@/hooks/quries/useMyRecruitments'
 import { useInView } from 'react-intersection-observer'
-import { useNavigate } from 'react-router'
+import { useLocation, useNavigate } from 'react-router'
 
 export default function Manage() {
   const navigate = useNavigate()
+  const location = useLocation()
   const [status, setStatus] = useState<'all' | 'open' | 'closed'>('all')
   const [sort, setSort] = useState<MyRecruitmentParams['sort']>('latest')
+  const [autoOpenId, setAutoOpenId] = useState<string | null>(null)
 
   const {
     data,
@@ -40,6 +42,17 @@ export default function Manage() {
   useEffect(() => {
     window.scrollTo({ top: 0, behavior: 'auto' })
   }, [])
+
+  // 알림/링크로 전달된 recruitment_uuid 또는 state 처리
+  useEffect(() => {
+    const state = location.state as { openRecruitmentId?: string } | null
+    const searchParams = new URLSearchParams(location.search)
+    const queryId = searchParams.get('recruitment_uuid')
+    if (state?.openRecruitmentId || queryId) {
+      setAutoOpenId(state?.openRecruitmentId ?? queryId ?? null)
+      navigate(location.pathname, { replace: true, state: {} })
+    }
+  }, [location.state, location.search, location.pathname, navigate])
 
   useEffect(() => {
     if (!inView || !hasNextPage || isFetchingNextPage) return
@@ -74,7 +87,12 @@ export default function Manage() {
       )}
       {!isLoading && !error && (
         <>
-          <ManageList postings={data} onDeleted={() => refetch()} />
+          <ManageList
+            postings={data}
+            onDeleted={() => refetch()}
+            autoOpenId={autoOpenId}
+            onAutoOpenConsumed={() => setAutoOpenId(null)}
+          />
           {isFetchingNextPage && <ManageCardSkeleton count={6} />}
           {!hasNextPage ? (
             <div className="flex-center mt-12 h-12 rounded-md bg-gray-400 text-center text-white">


### PR DESCRIPTION
<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #140

## 📑 구현 사항

- 지원자 목록/상세 API 연동: /v1/recruitments/{uuid}/applicants 무한스크롤 목록, /v1/applications/{id}/review 상세 조회 연결
- 승인/거절 처리: /v1/applications/{id}/accept|reject로 승인/거절 동작 및 로딩 상태 반영
- 알림 이동 개선: back_url이 /manage(쿼리 recruitment_uuid)이면 관리 페이지로 이동 후 해당 공고 지원내역 모달 자동 오픈
- 모달 UX 개선: 지원자 목록 로딩 시 스켈레톤, 데이터 없을 때 노데이터 메시지, 불필요한 초기 목데이터 제거

## 🌀 어려웠던 점 / 고민했던 부분

- 모달을 열지 않아도 카드마다 지원자 API가 호출되던 문제 → enabled 플래그로 모달 오픈 시에만 호출하도록 제어
- 알림에서 내려오는 다양한 back_url 형태(/manage, 쿼리 포함, 외부 도메인) 처리 시 SPA 네비게이션과 새 탭 열기 분기
- 무한스크롤 중 중복 호출 → sentinel 감지 시 쿨다운/락으로 과다 요청 방지

## 📸 구현 이미지

-

## ❇️ 코드 설명

### 지원자 목록 호출 지연
```tsx
// useApplicants(recruitmentUuid, pageSize, enabled)
const applicantsQuery = useApplicants(posting.uuid, 10, isModalOpen)
```
- 모달 열릴 때만 지원자 목록을 호출해 불필요한 API 호출 제거

### 지원자 상세/승인·거절 연동
```tsx
const detailQuery = useApplicantDetail(selectedApplicantId ?? undefined)
const approveMutation = useMutation(() => approveApplication(Number(selectedApplicantId)))
const rejectMutation = useMutation(() => rejectApplication(Number(selectedApplicantId)))
```
- 상세 모달이 선택된 지원자 id로 실제 상세를 불러오고, 승인/거절 버튼에서 API를 호출하며 로딩 상태/토스트 처리

### 알림 → 관리 페이지 모달 자동 오픈
```tsx
// NotificationModal: 동일 도메인은 navigate, 외부는 새 탭
const urlObj = new URL(alarm.backUrl, window.location.origin)
if (isSameOrigin) {
  navigate(urlObj.pathname + urlObj.search + urlObj.hash)
} ...
// Manage: 쿼리/ state의 recruitment_uuid로 모달 자동 오픈
const queryId = new URLSearchParams(location.search).get('recruitment_uuid')
if (state?.openRecruitmentId || queryId) {
  setAutoOpenId(...)
  navigate(location.pathname, { replace: true, state: {} })
}
```
- 알림 링크를 그대로 열고, Manage 페이지에서 uuid를 감지해 해당 공고 지원내역 모달을 자동으로 띄움

### 모달 로딩/빈 상태 UX
```tsx
{isLoading && renderSkeletons.map((_, idx) => <CardSkeleton key={`sk-${idx}`} />)}
{noData && (
  <div className="...">지원자가 없습니다...</div>
)}
```
- 로딩 시 스켈레톤, 데이터 없을 때 노데이터 메시지 표시로 깜빡임/목데이터 노출 제거

## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1.
