### PR TITLE
refactor: 공고 목록, 공고 상세 페이지 내 버튼 이동 및 버튼 추가

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -31,37 +31,39 @@ axiosInstance.interceptors.response.use(
   async function (error) {
     const originalRequest = error.config
     const status = error.response?.status
+    const { accessToken } = useAuthStore.getState()
     const isRefreshCall = originalRequest?.url?.includes(
       '/v1/accounts/token/refresh'
     )
 
-    // 네트워크 에러 처리
     if (!error.response) {
       showToast.error('네트워크 오류', '네트워크 연결을 확인해주세요.')
       return Promise.reject(error)
     }
 
-    // 401: 토큰 갱신 후 재시도
-    if (status === 401) {
-      if (isRefreshCall) {
-        useAuthStore.getState().clearAuth?.()
-        return Promise.reject(error)
-      }
+    if (status === 401 && !accessToken) {
+      return Promise.reject(error)
+    }
 
-      if (originalRequest._retry) {
+    if (status === 401) {
+      if (isRefreshCall || originalRequest._retry) {
         useAuthStore.getState().clearAuth?.()
         return Promise.reject(error)
       }
 
       originalRequest._retry = true
+
       try {
         if (!refreshPromise) {
           refreshPromise = getAccessTokenApi()
         }
-        const accessToken = await refreshPromise
+
+        const newAccessToken = await refreshPromise
         refreshPromise = null
-        useAuthStore.getState().setAccessToken(accessToken)
-        originalRequest.headers.Authorization = `Bearer ${accessToken}`
+
+        useAuthStore.getState().setAccessToken(newAccessToken)
+        originalRequest.headers.Authorization = `Bearer ${newAccessToken}`
+
         return axiosInstance(originalRequest)
       } catch (refreshError) {
         refreshPromise = null
@@ -74,7 +76,6 @@ axiosInstance.interceptors.response.use(
       return Promise.reject(error)
     }
 
-    // 403, 409, 500만 토스트 표시
     if (status === 403 || status === 409 || status === 500) {
       const errorMessage =
         error.response?.data?.error_detail ??

--- a/src/api/recruitments.ts
+++ b/src/api/recruitments.ts
@@ -93,3 +93,30 @@ export const postApplication = async (
 ): Promise<void> => {
   await axiosInstance.post('/v1/applications', payload)
 }
+
+export const getMyRecruitments = async (): Promise<
+  { uuid: string; title: string }[]
+> => {
+  const { data } = await axiosInstance.get('/v1/recruitments/mine')
+  return data
+}
+
+export interface RecruitmentBookmark {
+  id: string
+  recruitment_uuid: string
+  created_at?: string
+}
+
+export const createRecruitmentBookmark = async (
+  recruitmentId: string
+): Promise<void> => {
+  await axiosInstance.post('/v1/recruitment-bookmarks', {
+    recruitment_uuid: recruitmentId,
+  })
+}
+
+export const deleteRecruitmentBookmark = async (
+  bookmarkId: string
+): Promise<void> => {
+  await axiosInstance.delete(`/v1/recruitment-bookmarks/${bookmarkId}`)
+}

--- a/src/components/common/header/Header.tsx
+++ b/src/components/common/header/Header.tsx
@@ -4,16 +4,18 @@ import { ROUTE_PATHS } from '@/constant/route'
 import { useAuthStore } from '@/store/userStore'
 import { Menu } from 'lucide-react'
 import { useNavigate } from 'react-router'
-import { Button } from '../Button'
 import MobileModal from './MobileModal'
 import User from './User'
+
 interface HeaderProps {
   isSideBarOpen: boolean
   setIsSideBarOpen: (value: boolean) => void
 }
+
 function Header({ isSideBarOpen, setIsSideBarOpen }: HeaderProps) {
   const navigate = useNavigate()
-  const { loginState, setLoginState } = useAuthStore()
+  const { loginState } = useAuthStore()
+
   const handleSideBar = () => {
     setIsSideBarOpen(!isSideBarOpen)
   }
@@ -37,25 +39,12 @@ function Header({ isSideBarOpen, setIsSideBarOpen }: HeaderProps) {
         >
           <img src={logoImg} alt="logoImg" className="flex h-[35px] w-[35px]" />
           <h2 className="text-2xl font-bold text-[#CA8A04]">StudyHub</h2>
-          <Button
-            onClick={(e) => {
-              e.stopPropagation()
-              if (loginState === 'GUEST') {
-                setLoginState('USER')
-              } else {
-                setLoginState('GUEST')
-              }
-            }}
-          >
-            {loginState}
-          </Button>
         </div>
-        {/* 로그인 하지 않았을때의 UI */}
         {loginState === 'GUEST' && <Guest />}
-        {/* 로그인 했을때 UI */}
         {loginState === 'USER' && <User />}
       </div>
     </div>
   )
 }
+
 export default Header

--- a/src/components/postings/write/WriteForm.tsx
+++ b/src/components/postings/write/WriteForm.tsx
@@ -15,7 +15,7 @@ import {
   type Dispatch,
   type SetStateAction,
 } from 'react'
-import { useSearchParams, useLocation, useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import { getMyRecruitmentDetail } from '@/api/myRecruitment'
 import { getLecturesApi } from '@/api/lecture'
@@ -310,15 +310,18 @@ function ExtraInfoSection({
   )
 }
 
-export default function WriteForm() {
+export default function WriteForm({
+  recruitmentId: propRecruitmentId,
+}: {
+  recruitmentId?: string
+}) {
   const [selectedTags, setSelectedTags] = useState<TagOption[]>([])
   const [isTagModalOpen, setIsTagModalOpen] = useState(false)
   const [initialized, setInitialized] = useState(false)
   const [groupPrefilled, setGroupPrefilled] = useState(false)
-  const [searchParams] = useSearchParams()
   const navigate = useNavigate()
   const location = useLocation()
-  const recruitmentId = searchParams.get('recruitmentId')
+  const recruitmentId = propRecruitmentId
   const isEditing = location.pathname.includes('/edit') || !!recruitmentId
   const { state, actions, options } = useWriteRecruitmentForm(
     recruitmentId || undefined,
@@ -337,7 +340,6 @@ export default function WriteForm() {
   } = actions
   const lecturesFromGroup = options.groupDetail?.lectures ?? []
 
-  // 신규/다른 공고로 진입 시 내부 상태 초기화
   useEffect(() => {
     setInitialized(false)
     setGroupPrefilled(false)
@@ -369,7 +371,7 @@ export default function WriteForm() {
       return mapMyRecruitmentDetailToWrite(res)
     },
     enabled: !!recruitmentId,
-    staleTime: 0, // 페이지 진입 시마다 최신 정보 조회
+    staleTime: 0,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
     refetchOnMount: 'always',
@@ -385,7 +387,6 @@ export default function WriteForm() {
     0
   )
 
-  // 그룹이 선택된 상태라면 강의 합계(없으면 0)로 예상비용을 자동 세팅
   useEffect(() => {
     if (!state.studyGroupId) return
     const fallback = totalLecturePrice > 0 ? totalLecturePrice : 0
@@ -399,7 +400,6 @@ export default function WriteForm() {
     setEstimatedFee,
   ])
 
-  // 스터디 그룹 변경 시 강의 합계로 예상 비용 자동 입력 (강의 없으면 0)
   const prevGroupIdRef = useRef(state.studyGroupId)
   useEffect(() => {
     if (!state.studyGroupId) return
@@ -417,7 +417,6 @@ export default function WriteForm() {
     setEstimatedFee,
   ])
 
-  // 스터디 그룹 자동 설정: 상세/옵션이 모두 준비된 뒤 한 번만 수행
   useEffect(() => {
     if (groupPrefilled) return
     if (!detail?.study_group) return
@@ -445,7 +444,6 @@ export default function WriteForm() {
     setExpectedHeadcount(
       detail.expected_headcount ? String(detail.expected_headcount) : ''
     )
-    // 스터디 그룹 자동 설정은 옵션 준비 후 별도 effect에서 한 번만 처리
     if (detail.files?.length) {
       const presetFiles = detail.files.map(
         (f: { file_name: string; file_url: string }, idx: number) => {

--- a/src/mocks/handlers/user/index.ts
+++ b/src/mocks/handlers/user/index.ts
@@ -5,9 +5,10 @@ export const userInformationHandler = [
   http.get('/api/v1/accounts/me', () => {
     return HttpResponse.json(userInformation)
   }),
-  http.post('/api/v1/refresh', () => {
+  http.post('/api/v1/accounts/token/refresh', () => {
+    // 토큰 갱신
     return HttpResponse.json({
-      accessToken: 'mock-access-token-12345',
+      access: 'mock-access-token-12345',
     })
   }),
 ]

--- a/src/pages/postings/RecruitmentDetailPage.tsx
+++ b/src/pages/postings/RecruitmentDetailPage.tsx
@@ -2,7 +2,8 @@ import { useEffect, useState } from 'react'
 import { useParams, useNavigate, Navigate } from 'react-router-dom'
 import {
   getRecruitmentDetail,
-  incrementRecruitmentViews,
+  deleteRecruitment,
+  getMyRecruitments,
 } from '@/api/recruitments'
 import type { Recruitment } from '@/types/recruitment'
 import DetailHeader from '@/components/postings/detail/DetailHeader'
@@ -17,15 +18,13 @@ import { useAuthStore } from '@/store/userStore'
 export default function RecruitmentDetailPage() {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
-
   const [recruitment, setRecruitment] = useState<Recruitment | null>(null)
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [isApplicationModalOpen, setIsApplicationModalOpen] = useState(false)
-
-  const { user, loginState } = useAuthStore()
+  const [isAuthor, setIsAuthor] = useState(false)
+  const { loginState } = useAuthStore()
   const isLoggedIn = loginState === 'USER'
-  const isAuthor = isLoggedIn && recruitment?.authorId === user?.id
 
   useEffect(() => {
     if (!id) return
@@ -37,7 +36,6 @@ export default function RecruitmentDetailPage() {
       try {
         const data = await getRecruitmentDetail(id)
         setRecruitment(data)
-        await incrementRecruitmentViews(id).catch(() => {})
       } catch {
         setError('공고를 불러오는데 실패했습니다.')
       } finally {
@@ -47,6 +45,55 @@ export default function RecruitmentDetailPage() {
 
     fetchDetail()
   }, [id])
+
+  useEffect(() => {
+    if (!id || !isLoggedIn) {
+      setIsAuthor(false)
+      return
+    }
+
+    const checkAuthor = async () => {
+      try {
+        const myRecruitments = await getMyRecruitments()
+        const myRecruitmentIds = Array.isArray(myRecruitments)
+          ? myRecruitments.map((r) => r.uuid)
+          : []
+        setIsAuthor(myRecruitmentIds.includes(id))
+      } catch {
+        setIsAuthor(false)
+      }
+    }
+
+    checkAuthor()
+  }, [id, isLoggedIn])
+
+  const handleBookmark = () => {
+    showToast.warning('준비 중', '북마크 기능은 추후 업데이트 예정입니다.')
+  }
+
+  const handleShare = async () => {
+    try {
+      await navigator.clipboard.writeText(window.location.href)
+      showToast.success('링크 복사', '링크가 클립보드에 복사되었습니다')
+    } catch {
+      showToast.error('복사 실패', '링크 복사에 실패했습니다')
+    }
+  }
+
+  const handleDelete = async () => {
+    if (!id) return
+
+    const confirmed = window.confirm('정말 삭제하시겠습니까?')
+    if (!confirmed) return
+
+    try {
+      await deleteRecruitment(id)
+      showToast.success('삭제 완료', '공고가 삭제되었습니다')
+      navigate('/recruitments')
+    } catch {
+      showToast.error('삭제 실패', '공고 삭제에 실패했습니다')
+    }
+  }
 
   if (!id) {
     return <Navigate to="/recruitments" replace />
@@ -97,13 +144,9 @@ export default function RecruitmentDetailPage() {
           onEdit={
             isAuthor ? () => navigate(`/recruitments/edit/${id}`) : undefined
           }
-          onDelete={
-            isAuthor
-              ? () => showToast.warning('준비 중', '삭제 기능 준비중')
-              : undefined
-          }
-          onBookmark={() => {}}
-          onShare={() => {}}
+          onDelete={isAuthor ? handleDelete : undefined}
+          onBookmark={handleBookmark}
+          onShare={handleShare}
         />
       </div>
 

--- a/src/pages/postings/RecruitmentListPage.tsx
+++ b/src/pages/postings/RecruitmentListPage.tsx
@@ -5,7 +5,7 @@ import RecruitmentCard from '@/components/postings/recruitment/RecruitmentCard'
 import { useRecruitments } from '@/hooks/recruitment/useRecruitments'
 import { useAuthStore } from '@/store/userStore'
 import { QueryClient } from '@tanstack/react-query'
-import { ArrowUp, Plus, Search } from 'lucide-react'
+import { ArrowUp, Plus, Search, List } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
@@ -42,12 +42,11 @@ export default function RecruitmentListPage() {
     navigate(`/recruitments/${id}`)
   }
 
-  /* 데이터 프리페칭 */
-  const queryClient = new QueryClient()
   useEffect(() => {
+    const queryClient = new QueryClient()
     const prefetchData = async () => {
       await queryClient.prefetchQuery({
-        queryKey: ['lecture-recommend'], //프레페칭 키와 함수 적용
+        queryKey: ['lecture-recommend'],
         queryFn: () => getUserRecommendsLecturesApi(),
       })
     }
@@ -68,11 +67,32 @@ export default function RecruitmentListPage() {
   return (
     <div className="min-h-screen bg-gray-50">
       <div className="mx-auto max-w-6xl p-4 md:p-6">
-        <div className="mb-6">
-          <h1 className="text-2xl font-bold md:text-3xl">스터디 구인 공고</h1>
-          <p className="mt-1 text-sm text-gray-600 md:text-base">
-            새로운 스터디 팀원을 찾거나 관심있는 스터디에 참여해보세요!
-          </p>
+        <div className="mb-6 flex items-start justify-between">
+          <div>
+            <h1 className="text-2xl font-bold md:text-3xl">스터디 구인 공고</h1>
+            <p className="mt-1 text-sm text-gray-600 md:text-base">
+              새로운 스터디 팀원을 찾거나 관심있는 스터디에 참여해보세요!
+            </p>
+          </div>
+
+          {isLoggedIn && (
+            <div className="flex gap-2">
+              <button
+                onClick={() => navigate('/manage')}
+                className="flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+              >
+                <List className="h-4 w-4" />
+                공고 관리
+              </button>
+              <button
+                onClick={() => navigate('/write')}
+                className="flex items-center gap-2 rounded-lg bg-yellow-400 px-4 py-2 text-sm font-medium text-white hover:bg-yellow-500"
+              >
+                <Plus className="h-4 w-4" />
+                공고 작성하기
+              </button>
+            </div>
+          )}
         </div>
 
         {isLoggedIn && (
@@ -165,7 +185,7 @@ export default function RecruitmentListPage() {
         )}
       </div>
 
-      <div className="fixed right-6 bottom-6">
+      <div className="fixed right-8 bottom-25 z-50">
         {showScrollTop && (
           <button
             onClick={scrollToTop}

--- a/src/pages/postings/Write.tsx
+++ b/src/pages/postings/Write.tsx
@@ -1,11 +1,17 @@
+import { useParams, useSearchParams } from 'react-router-dom'
 import WriteForm from '@/components/postings/write/WriteForm'
 import WriteHeader from '@/components/postings/write/WriteHeader'
 
 export default function Write() {
+  const { id } = useParams<{ id: string }>()
+  const [searchParams] = useSearchParams()
+
+  const recruitmentId = id || searchParams.get('recruitmentId')
+
   return (
     <div className="mx-auto flex flex-col gap-6">
       <WriteHeader />
-      <WriteForm />
+      <WriteForm recruitmentId={recruitmentId || undefined} />
     </div>
   )
 }

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -48,6 +48,15 @@ function AppRoutes() {
           }
         />
 
+        <Route
+          path="/recruitments/edit/:id"
+          element={
+            <ProtectedRoute>
+              <WritePage />
+            </ProtectedRoute>
+          }
+        />
+
         <Route path="/recruitments" element={<RecruitmentListPage />} />
         <Route path="/recruitments/:id" element={<RecruitmentDetailPage />} />
 


### PR DESCRIPTION
<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #134 

## 📑 구현 사항

- 공고 작성자 확인 로직 구현 및 작성자 전용 수정/삭제 버튼 추가
- 로그인 유저는 공고 목록 우측 상단에 내 공고 관리, 작성하기 버튼 보이도록 추가

## 🌀 어려웠던 점 / 고민했던 부분

-

## 📸 구현 이미지

-

## ❇️ 코드 설명

-

## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1.
