### PR TITLE
fix: 가격 표시 및 QueryClient 중복 생성 개선

### DIFF
--- a/src/components/postings/detail/DetailContent.tsx
+++ b/src/components/postings/detail/DetailContent.tsx
@@ -1,5 +1,5 @@
 import type { Recruitment } from '@/types/recruitment'
-import { FileText, Download } from 'lucide-react'
+import { Download, FileText } from 'lucide-react'
 
 interface Props {
   recruitment: Recruitment
@@ -41,7 +41,11 @@ export default function DetailContent({ recruitment }: Props) {
                   </p>
                   <div className="flex items-center justify-between pt-2">
                     <p className="text-lg font-bold text-yellow-600">
-                      {(lecture.price ?? 0).toLocaleString()}원
+                      {lecture.price === 0 ? (
+                        <h4>무료</h4>
+                      ) : (
+                        <h4>₩{lecture.price.toLocaleString('ko-KR')}</h4>
+                      )}
                     </p>
 
                     <a

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,9 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router'
 import App from './App'
 import './index.css'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { BrowserRouter } from 'react-router'
 
 declare global {
   interface Window {
@@ -26,7 +26,7 @@ async function enableMocking() {
   })
 }
 
-const queryClient = new QueryClient({
+export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       staleTime: 5 * 60 * 1000,

--- a/src/pages/CoursesPage.tsx
+++ b/src/pages/CoursesPage.tsx
@@ -88,6 +88,7 @@ export default function Courses() {
       <section className="courses_filter flex flex-col items-center gap-2 rounded-md border border-gray-200 bg-white p-6 sm:flex-row">
         <Input
           prefix={<Search />}
+          placeholder="강의명이나 강사명으로 검색..."
           className="h-[38px]"
           value={inputValue}
           onChange={(e) => setInputValue(e.target.value)}

--- a/src/pages/postings/RecruitmentListPage.tsx
+++ b/src/pages/postings/RecruitmentListPage.tsx
@@ -1,13 +1,15 @@
 import { getUserRecommendsLecturesApi } from '@/api/lecture'
 import { getRecruitmentTags } from '@/api/recruitmentTag'
+
 import { Select } from '@/components/common'
 import PublicBanner from '@/components/postings/recruitment/PublicBanner'
 import RecommendedSection from '@/components/postings/recruitment/RecommendedSection'
 import RecruitmentCard from '@/components/postings/recruitment/RecruitmentCard'
 import { useRecruitments } from '@/hooks/recruitment/useRecruitments'
+import { queryClient } from '@/main'
 import { sortDataRecruitment } from '@/mappers/recruitment/mapper'
 import { useAuthStore } from '@/store/userStore'
-import { QueryClient, useQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { ArrowDownWideNarrow, ArrowUp, List, Plus, Search } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
@@ -50,7 +52,6 @@ export default function RecruitmentListPage() {
   }
 
   useEffect(() => {
-    const queryClient = new QueryClient()
     const prefetchData = async () => {
       await queryClient.prefetchQuery({
         queryKey: ['lecture-recommend'],


### PR DESCRIPTION
- 강의 가격 0원일 때 '무료' 표시
- QueryClient를 main.tsx에서 export하여 재사용
- import 정렬 및 검색 placeholder 추가

<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #

## 📑 구현 사항

-

## 🌀 어려웠던 점 / 고민했던 부분

-

## 📸 구현 이미지

-

## ❇️ 코드 설명

-

## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1.
